### PR TITLE
Fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed an issue where calling `joins` or `includes` before (or after) `query` fails
+* Ensure that `stash_id` is set if `cs_put` is called outside of a callback
+
+### Changed
+
+* Don't call `save` when bulk reindexing to avoid updating timestamps unnecessarily
+
 ## [0.2.0]
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_stash (0.1.2)
+    active_stash (0.2.0)
       activerecord
       cipherstash-client (>= 0.3.0)
 
@@ -31,20 +31,18 @@ GEM
     aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
     cbor (0.5.9.6)
-    cipherstash-client (0.3.0)
+    cipherstash-client (0.4.0)
       aws-sdk-core (~> 3.0)
       aws-sdk-kms (~> 1.0)
       cbor (~> 0.5.9.6)
       cipherstash-grpc (= 0.20220428.11)
-      deep_merge (~> 1.2)
-      enveloperb
-      ore-rs
+      enveloperb (~> 0.0)
+      ore-rs (~> 0.0)
     cipherstash-grpc (0.20220428.11)
       grpc
     concurrent-ruby (1.1.10)
-    deep_merge (1.2.2)
     diff-lcs (1.5.0)
-    enveloperb (0.1.4)
+    enveloperb (0.1.5)
       fiddle (~> 1.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)

--- a/lib/active_stash/relation.rb
+++ b/lib/active_stash/relation.rb
@@ -4,13 +4,13 @@ module ActiveStash
   class Relation < ::ActiveRecord::Relation
     include ActiveStash::RelationHelp::Compatability
 
-    stash_wrap(:select, :all)
     # TODO: Add count aggregate support
     stash_unsupported(:where, :count)
+    stash_wrap(:select, :all, :includes, :joins, :annotate)
 
-    def initialize(model)
-      @klass = model
-      @scope = model
+    def initialize(scope)
+      @klass = scope
+      @scope = scope
     end
 
     def query(*args, &block)
@@ -80,6 +80,10 @@ module ActiveStash
 
     def stash_query?
       @query || @stash_order
+    end
+
+    def inspect
+      @scope.inspect
     end
 
     protected

--- a/lib/active_stash/search.rb
+++ b/lib/active_stash/search.rb
@@ -131,7 +131,7 @@ module ActiveStash # :nodoc:
 
       # Perform a query using the CipherStash collection indexes
       def query(*args, &block)
-        ::ActiveStash::Relation.new(self).query(*args, &block)
+        ::ActiveStash::Relation.new(current_scope || self).query(*args, &block)
       end
 
       # Reindex all records into CipherStash

--- a/lib/active_stash/search.rb
+++ b/lib/active_stash/search.rb
@@ -136,7 +136,7 @@ module ActiveStash # :nodoc:
 
       # Reindex all records into CipherStash
       def reindex
-        find_each(&:save!)
+        find_each(&:cs_put)
         true
       end
 

--- a/lib/active_stash/search.rb
+++ b/lib/active_stash/search.rb
@@ -93,14 +93,13 @@ module ActiveStash # :nodoc:
       end
     end
 
-    def ensure_stash_id # :nodoc:
-      self.stash_id ||= SecureRandom.uuid
-    end
-
     # Index this record into CipherStash
     def cs_put
       ActiveStash::Logger.info("Indexing #{self.stash_id}")
+      ensure_stash_id
 
+      # TODO: If this fails, throw :abort
+      # it should unset stash_id if this record did not already exist
       self.class.collection.upsert(
         self.stash_id,
         self.serializable_hash(except: [self.class.primary_key, :stash_id]),
@@ -112,6 +111,11 @@ module ActiveStash # :nodoc:
     def cs_delete
       self.class.collection.delete(self.stash_id)
     end
+
+    private
+      def ensure_stash_id
+        self.stash_id ||= SecureRandom.uuid
+      end
 
     module ClassMethods
       attr_writer :collection_name

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -158,5 +158,29 @@ RSpec.describe ActiveStash::Search do
       ))
     end
   end
+
+  describe "#select" do
+    it "selects given fields when chained after query" do
+      result = User.query(first_name: "Emma").select(:first_name, :last_name)
+      expect(result[0].first_name).to eq("Emma")
+      expect(result[0].last_name).to eq("Bunton")
+      expect(result[0].id).to be_nil
+
+      expect {
+        result[0].dob
+      }.to raise_error(ActiveModel::MissingAttributeError)
+    end
+
+    it "selects given fields when query is chained after select" do
+      result = User.select(:first_name, :last_name).query(first_name: "Emma")
+      expect(result[0].first_name).to eq("Emma")
+      expect(result[0].last_name).to eq("Bunton")
+      expect(result[0].id).to be_nil
+
+      expect {
+        result[0].dob
+      }.to raise_error(ActiveModel::MissingAttributeError)
+    end
+  end
 end
 

--- a/spec/search_spec.rb
+++ b/spec/search_spec.rb
@@ -1,0 +1,52 @@
+require_relative "support/user"
+require_relative "support/migrations/create_users"
+require 'rake'
+load "tasks/active_stash.rake"
+
+RSpec.describe ActiveStash::Search do
+  before(:all) do
+    ActiveRecord::Base.establish_connection(
+      adapter: 'postgresql',
+      host: 'localhost',
+      username: 'dan',
+      database: 'activestash_test'
+    )
+
+    CreateUsers.migrate(:up)
+
+    schema = ActiveStash::SchemaBuilder.new(User).build
+    client = CipherStash::Client.new(logger: ActiveStash::Logger.instance)
+    client.create_collection(User.collection_name, schema)
+  end
+
+  after(:all) do
+    User.collection.drop
+    CreateUsers.migrate(:down)
+  end
+
+  describe "#cs_put" do
+    let!(:user) do
+      User.create!(
+        first_name: "James",
+        last_name: "Hetfield",
+        gender: "M",
+        dob: "Aug 3, 1963",
+        created_at: 10.days.ago,
+        title: "Mr",
+        email: "james@metalica.net"
+      )
+    end
+
+    it "should have stash_id set" do
+      expect(user.stash_id).not_to be_nil
+    end
+
+    it "should set stash_id when indexing an existing record" do
+      user.update_column(:stash_id, nil)
+      expect(user.stash_id).to be_nil
+      user.cs_put
+      expect(user.stash_id).not_to be_nil
+    end
+  end
+end
+


### PR DESCRIPTION
### Fixed

* Fixed an issue where calling `joins` or `includes` before (or after) `query` fails
* Ensure that `stash_id` is set if `cs_put` is called outside of a callback

### Changed

* Don't call `save` when bulk reindexing to avoid updating timestamps unnecessarily