### PR TITLE
Readme and setup cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Range indexes on strings typically only work for ordering.
 |-----------------|-------------------|---------------------|
 | `match`         | `=~`              | `User.query { |q| q.name =~ "foo" }` |
 | `exact`         | `==`              | `User.query(email: "foo@example.com)` |
-| `range`         | `<`, `<=`, `==`, `>=`, >` | `User.query.order(:email)` |
+| `range`         | `<`, `<=`, `==`, `>=`, `>` | `User.query.order(:email)` |
 
 ### Numeric Types
 
@@ -95,7 +95,7 @@ Range indexes on strings typically only work for ordering.
 
 | Indexes Created | Allowed Operators | Example |
 |-----------------|-------------------|---------------------|
-| `range`         | `<`, `<=`, `==`, `>=`, >` | `User.query { |q| q.dob > 20.years.ago }` |
+| `range`         | `<`, `<=`, `==`, `>=`, `>` | `User.query { \|q\| q.dob > 20.years.ago }` |
 
 ### Overriding Automatically Created Indexes
 
@@ -266,9 +266,6 @@ User.order(:dob)
 # Without a default scope you'd need to call
 User.query.order(:dob)
 ```
-
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/activestash`. To experiment with that code, run `bin/console` for an interactive prompt.
-
 
 ## Managing Access Keys
 

--- a/bin/setup
+++ b/bin/setup
@@ -4,5 +4,3 @@ IFS=$'\n\t'
 set -vx
 
 bundle install
-
-# Do any other automated setup that you need to do here


### PR DESCRIPTION
This PR cleans up a few minor details in README.md and bin/setup.

README.md changes:
* Add missing backticks in  index types tables
* Escape pipes in range query example to fix table formatting
* Remove generic text generated by `bundle gem`

bin/setup:
* Remove comment that gets printed to stdout
