### PR TITLE
Implement between operator in range queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Range indexes on strings typically only work for ordering.
 
 | Indexes Created | Allowed Operators | Example |
 |-----------------|-------------------|---------------------|
-| `range`         | `<`, `<=`, `==`, `>=`, `>` | `User.query { \|q\| q.dob > 20.years.ago }` |
+| `range`         | `<`, `<=`, `==`, `>=`, `>`, `between` | `User.query { \|q\| q.dob > 20.years.ago }` |
 
 ### Overriding Automatically Created Indexes
 

--- a/lib/active_stash/query_builder.rb
+++ b/lib/active_stash/query_builder.rb
@@ -62,7 +62,7 @@ module ActiveStash
     end
 
     class Field < BasicObject # :nodoc:
-      attr_reader :index, :value, :op
+      attr_reader :index, :values, :op
 
       def initialize(name, available_indexes)
         @name = name
@@ -84,7 +84,7 @@ module ActiveStash
         @op ||= :match
         set(value)
       end
-      
+
       def >(value)
         @op ||= :gt
         set(value)
@@ -105,8 +105,13 @@ module ActiveStash
         set(value)
       end
 
+      def between(min, max)
+        @op ||= :between
+        set(min, max)
+      end
+
       private
-      def set(value)
+      def set(*values)
         # Find the appropriate index to use
         @index = @available_indexes.find do |index|
           index.valid_op?(@op)
@@ -116,7 +121,7 @@ module ActiveStash
           ::Kernel.raise "No available index for '#{@name}' using '#{@op}'"
         end
 
-        @value ||= maybe_cast(value)
+        @values ||= values.map { |value| maybe_cast(value) }
         self
       end
 

--- a/lib/active_stash/relation.rb
+++ b/lib/active_stash/relation.rb
@@ -64,11 +64,11 @@ module ActiveStash
             q.add_constraint(
               constraint.index.name,
               constraint.op.to_s,
-              constraint.value
+              *constraint.values
             )
           end
         end.records.map(&:id)
-        
+
         relation = @scope.where(stash_id: ids)
         relation = relation.in_order_of(:stash_id, ids) if @stash_order
         @loaded = true

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -80,6 +80,14 @@ RSpec.describe ActiveStash::Search do
 
       expect(results.map(&:first_name)).to eq(%w(Lars Robert))
     end
+
+    it "by range between" do
+      results = User.query { |q|
+        q.dob.between("1974-01-12".to_date, "1974-06-17".to_date)
+      }.select(:first_name)
+
+      expect(results.map(&:first_name)).to eq(%w(Melanie Victoria))
+    end
   end
 
   describe "limit and offset" do
@@ -171,4 +179,3 @@ RSpec.describe ActiveStash::Search do
     end
   end
 end
-


### PR DESCRIPTION
This PR implements the `between` operator in range queries.

`between` takes two separate `min` and `max` args for consistency with the implementation in StashRB, but I'm open to other ideas (e.g. if we think a range would be cleaner).