### PR TITLE
Allow client config via Rails config and credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,34 @@ $ rails db:migrate
 
 The above command also ensures that an index is created on `stash_id`.
 
+## Configuration
+
+ActiveStash supports all CipherStash configuration described in [the docs](https://docs.cipherstash.com/reference/client-configuration.html).
+
+In addition to configuration via JSON files and environment variables, ActiveStash supports Rails config and credentials.
+
+For example, to use a specific profile in development, you could include the following in `config/environments/development.rb`:
+```ruby
+Rails.application.configure do
+  config.active_stash.profile_name = "dev-profile"
+
+  # Other config...
+end
+```
+
+For secrets, you can add ActiveStash config to your credentials (`rails credentials:edit --environment <env>`):
+```yaml
+active_stash:
+  aws_secret_access_key: your_secret
+```
+
+You can also use an initializer (e.g. `config/initializers/active_stash.rb`):
+```ruby
+ActiveStash.configure do |config|
+  config.aws_secret_access_key = Rails.application.credentials.aws.secret_access_key
+end
+```
+
 ## Index Types
 
 CipherStash supports 3 main types of indexes: `exact`, `range` (allows queries like `<` and `>`)

--- a/activestash.gemspec
+++ b/activestash.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/cipherstash/activestash"
   spec.metadata["changelog_uri"] = "https://github.com/cipherstash/activestash/CHANGELOG.md"
 
-  spec.add_runtime_dependency "cipherstash-client", ">= 0.8.1"
+  spec.add_runtime_dependency "cipherstash-client", ">= 0.9.0"
   spec.add_runtime_dependency "activerecord"
   spec.add_runtime_dependency "terminal-table", "~> 3.0"
 

--- a/lib/active_stash.rb
+++ b/lib/active_stash.rb
@@ -25,9 +25,7 @@ module ActiveStash
   end
 
   Config.class_eval do
-    CipherStash::Client.client_options.each do |option|
-      attr_accessor option.to_s.underscore.to_sym
-    end
+    attr_accessor *CipherStash::Client.client_options.map { |o| o.to_s.underscore.to_sym }
   end
 
   def self.config

--- a/lib/active_stash.rb
+++ b/lib/active_stash.rb
@@ -14,4 +14,27 @@ require "cipherstash/client"
 
 module ActiveStash
   class Error < StandardError; end
+
+  class Config
+    def to_client_opts
+      self.instance_values
+        .map { |key, value| [key.to_s.camelize(:lower).to_sym, value] }
+        .to_h
+        .compact
+    end
+  end
+
+  Config.class_eval do
+    CipherStash::Client.client_options.each do |option|
+      attr_accessor option.to_s.underscore.to_sym
+    end
+  end
+
+  def self.config
+    @@config ||= Config.new
+  end
+
+  def self.configure
+    yield self.config
+  end
 end

--- a/lib/active_stash/collection_proxy.rb
+++ b/lib/active_stash/collection_proxy.rb
@@ -64,7 +64,10 @@ module ActiveStash
       end
 
       def client
-        @client = CipherStash::Client.new(logger: ActiveStash::Logger.instance)
+        @client = CipherStash::Client.new(
+          logger: ActiveStash::Logger.instance,
+          **ActiveStash.config.to_client_opts
+        )
       end
 
       def logger

--- a/lib/active_stash/railtie.rb
+++ b/lib/active_stash/railtie.rb
@@ -4,10 +4,10 @@ module ActiveStash
 
     initializer "active_stash.configure" do |app|
       ActiveStash.configure do |config|
-        app.config.active_stash.each { |key, value| config.send("#{key}=", value) }
+        app.config.active_stash.each { |key, value| config.public_send("#{key}=", value) }
 
         if active_stash_credentials = app.credentials.active_stash
-          active_stash_credentials.each { |key, value| config.send("#{key}=", value) }
+          active_stash_credentials.each { |key, value| config.public_send("#{key}=", value) }
         end
       end
     end

--- a/lib/active_stash/railtie.rb
+++ b/lib/active_stash/railtie.rb
@@ -1,5 +1,17 @@
 module ActiveStash
   class Railtie < Rails::Railtie
+    config.active_stash = ActiveSupport::OrderedOptions.new
+
+    initializer "active_stash.configure" do |app|
+      ActiveStash.configure do |config|
+        app.config.active_stash.each { |key, value| config.send("#{key}=", value) }
+
+        if active_stash_credentials = app.credentials.active_stash
+          active_stash_credentials.each { |key, value| config.send("#{key}=", value) }
+        end
+      end
+    end
+
     rake_tasks do
       load "tasks/active_stash.rake"
     end


### PR DESCRIPTION
This change implements configuration via Rails config (e.g. in
environment-specific config, application.rb, an initializer, etc.)
as well as Rails credentials files.