### PR TITLE
Fix spec race conditions

### DIFF
--- a/spec/put_spec.rb
+++ b/spec/put_spec.rb
@@ -1,13 +1,15 @@
 require_relative "support/user"
 require_relative "support/migrations/create_users"
 
-RSpec.describe ActiveStash::Search do
+RSpec.describe "ActiveStash::Search.cs_put" do
   describe "#cs_put" do
     before(:example) do
       User.collection.create!
+      User.delete_all
     end
 
     after(:example) do
+      User.delete_all
       User.collection.drop!
     end
 

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -1,12 +1,14 @@
 require_relative "support/user"
 require_relative "support/migrations/create_users"
 
-RSpec.describe ActiveStash::Search do
+RSpec.describe "ActiveStash::Search.query" do
   before(:context) do
     User.collection.create!
+    User.delete_all
   end
 
   after(:context) do
+    User.delete_all
     User.collection.drop!
   end
 


### PR DESCRIPTION
1. Ensure the specs have unique group names as this affects when
   before(:context) and after(:context) runs and avoids races with
   create and deleting collections
2. Explicitly delete data created in the specs before and after tests.