### PR TITLE
Bump cipherstash-client to 0.10.3

### DIFF
--- a/activestash.gemspec
+++ b/activestash.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/cipherstash/activestash"
   spec.metadata["changelog_uri"] = "https://github.com/cipherstash/activestash/CHANGELOG.md"
 
-  spec.add_runtime_dependency "cipherstash-client", ">= 0.10.2"
+  spec.add_runtime_dependency "cipherstash-client", ">= 0.10.3"
   spec.add_runtime_dependency "activerecord"
   spec.add_runtime_dependency "terminal-table", "~> 3.0"
 


### PR DESCRIPTION
This release fixes an issue that prevented an error message from being
generated correctly when a collection is not found.