### PR TITLE
DRY up before/after blocks in consistency spec

### DIFF
--- a/spec/active_stash/consistency_spec.rb
+++ b/spec/active_stash/consistency_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "constistency checks" do
       expect { User.collection.info }.to_not raise_error
     end
 
-    describe "when the backing collection exists but is missing an index" do
+    describe "but is missing an index" do
       it "raises an error" do
         expect { UserInconsistent.collection(true).info }.to raise_error(ActiveStash::CollectionDivergedError)
         UserInconsistent.collection.drop!
@@ -27,7 +27,7 @@ RSpec.describe "constistency checks" do
       end
     end
 
-    describe "when the backing collection exists but has an additional index" do
+    describe "but has an additional index" do
       it "raises an error" do
         expect { UserInconsistent2.collection(true).info }.to raise_error(ActiveStash::CollectionDivergedError)
       end

--- a/spec/active_stash/consistency_spec.rb
+++ b/spec/active_stash/consistency_spec.rb
@@ -11,32 +11,26 @@ RSpec.describe "constistency checks" do
   end
 
   describe "when the backing collection exists" do
-    before { User.collection.create! }
-    after { User.collection.drop! }
+    before(:example) { User.collection.create! }
+    after(:example) { User.collection.drop! }
 
     it "does not raise an error" do
       expect { User.collection.info }.to_not raise_error
     end
-  end
 
-  describe "when the backing collection exists but is missing an index" do
-    before { User.collection.create! }
-    after { User.collection.drop! }
-
-    it "raises an error" do
-      expect { UserInconsistent.collection(true).info }.to raise_error(ActiveStash::CollectionDivergedError)
-      UserInconsistent.collection.drop!
-      UserInconsistent.collection.create!
-      expect { UserInconsistent.collection(true).info }.to_not raise_error
+    describe "when the backing collection exists but is missing an index" do
+      it "raises an error" do
+        expect { UserInconsistent.collection(true).info }.to raise_error(ActiveStash::CollectionDivergedError)
+        UserInconsistent.collection.drop!
+        UserInconsistent.collection.create!
+        expect { UserInconsistent.collection(true).info }.to_not raise_error
+      end
     end
-  end
 
-  describe "when the backing collection exists but has an additional index" do
-    before { User.collection.create! }
-    after { User.collection.drop! }
-
-    it "raises an error" do
-      expect { UserInconsistent2.collection(true).info }.to raise_error(ActiveStash::CollectionDivergedError)
+    describe "when the backing collection exists but has an additional index" do
+      it "raises an error" do
+        expect { UserInconsistent2.collection(true).info }.to raise_error(ActiveStash::CollectionDivergedError)
+      end
     end
   end
 end


### PR DESCRIPTION
I'm unsure what the semantics are of before/after with no-arg (just a
block) so I'm being explicit.