### PR TITLE
Escape pipes in "String and Text" query example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Range indexes on strings typically only work for ordering.
 
 | Indexes Created | Allowed Operators | Example |
 |-----------------|-------------------|---------------------|
-| `match`         | `=~`              | `User.query { |q| q.name =~ "foo" }` |
+| `match`         | `=~`              | `User.query { \|q\| q.name =~ "foo" }` |
 | `exact`         | `==`              | `User.query(email: "foo@example.com)` |
 | `range`         | `<`, `<=`, `==`, `>=`, `>` | `User.query.order(:email)` |
 


### PR DESCRIPTION
This fixes broken formatting in the markdown table.