### PR TITLE
Remove .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
----
-language: ruby
-cache: bundler
-rvm:
-  - 2.7.2
-before_install: gem install bundler -v 2.1.4


### PR DESCRIPTION
This file was created when the project was generated with bundler,
but is not actually used.