### PR TITLE
Add net-http as a dev dependancy

### DIFF
--- a/activestash.gemspec
+++ b/activestash.gemspec
@@ -31,6 +31,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency  "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
+  if RUBY_VERSION >= '3.0'
+    spec.add_development_dependency 'net-http', '~> 0.2.2'
+  end
+  
   spec.files = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*"]
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
ActiveStash has a dependancy on Rails in dev because it's needed in order to run the test suite that depends on Railties.

When adding ActiveStash and running through the getting started guide locally on a rails app, I was getting these warning messages

```
/Users/fionamccawley/.asdf/installs/ruby/2.7.4/lib/ruby/2.7.0/net/protocol.rb:66: warning: already initialized constant Net::ProtocRetryError
/Users/fionamccawley/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/net-protocol-0.1.3/lib/net/protocol.rb:68: warning: previous definition of ProtocRetryError was here
/Users/fionamccawley/.asdf/installs/ruby/2.7.4/lib/ruby/2.7.0/net/protocol.rb:206: warning: already initialized constant Net::BufferedIO::BUFSIZE
```

![Kapture 2022-05-26 at 15 55 39](https://user-images.githubusercontent.com/26052576/170606295-a128ef9a-86c5-4ff8-9453-6a8907f6fa2a.gif)


https://github.com/ruby/net-protocol/issues/10

Adding `net-http` to the gem file in the rails app silences these warning messages.