### PR TITLE
Add rake task to launch signup

### DIFF
--- a/activestash.gemspec
+++ b/activestash.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "cipherstash-client", ">= 0.10.4"
   spec.add_runtime_dependency "activerecord"
   spec.add_runtime_dependency "terminal-table", "~> 3.0"
+  spec.add_runtime_dependency "launchy", "~> 2.5"
 
   spec.add_development_dependency 'pg'
   spec.add_development_dependency 'rails', '>= 6.0'

--- a/lib/tasks/active_stash.rake
+++ b/lib/tasks/active_stash.rake
@@ -1,6 +1,7 @@
 require "cipherstash/client"
 require "active_stash"
 require "terminal-table"
+require "launchy"
 
 def stash_enabled_models
   Dir.glob("#{Rails.root}/app/models/*.rb").each { |file| require file }
@@ -21,6 +22,21 @@ def error(message)
 end
 
 namespace :active_stash do
+  desc "Signup"
+  task(:signup => :environment) do
+    info("")
+    info("")
+    info("")
+    info("Opening your browser to complete signup.......")
+    info("")
+    info("")
+    info("")
+    Launchy.open "https://console.cipherstash.com/?signup=active-stash"
+    info("")
+    info("")
+    info("")
+  end
+
   desc "Login to stash workspace"
   task :login, [:workspace] do |task, args|
     CipherStash::Client::Profile.create(ENV.fetch("CS_PROFILE_NAME", "default"), ActiveStash::Logger.instance, workspace: args[:workspace])


### PR DESCRIPTION
Ticket https://www.notion.so/cipherstash/Rake-task-to-sign-up-to-CipherStash-c5acb5ae50024808ad405fb8faabcff4

This console PR will be merged first. https://github.com/cipherstash/console/pull/70

I couldn't work out how to auto login back in the terminal after the sign up flow. So the above console PR displays the next step for the user to head back to the terminal and use the rake task to login.

