### PR TITLE
Update net-http to be a runtime dep

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,5 +36,7 @@ jobs:
         run: echo ${{ env.ACTIVE_STASH_TEST_COLLECTION_PREFIX }}
       - name: "Clear out database"
         run: psql -d ${{ env.PGDATABASE }} -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;'
+      - name: "Install default uri gem version"
+        run: gem install --default -v0.11.0 uri
       - name: Run the tests
         run: bundle exec rake spec

--- a/activestash.gemspec
+++ b/activestash.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activerecord"
   spec.add_runtime_dependency "terminal-table", "~> 3.0"
   spec.add_runtime_dependency "launchy", "~> 2.5"
+  spec.add_runtime_dependency 'net-http', '~> 0.2.2' # https://github.com/ruby/net-protocol/issues/10
 
   spec.add_development_dependency 'pg'
   spec.add_development_dependency 'rails', '>= 6.0'
@@ -32,10 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency  "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  if RUBY_VERSION >= '3.0'
-    spec.add_development_dependency 'net-http', '~> 0.2.2'
-  end
-  
   spec.files = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*"]
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/activestash.gemspec
+++ b/activestash.gemspec
@@ -25,8 +25,12 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activerecord"
   spec.add_runtime_dependency "terminal-table", "~> 3.0"
   spec.add_runtime_dependency "launchy", "~> 2.5"
-  spec.add_runtime_dependency 'net-http', '~> 0.2.2' # https://github.com/ruby/net-protocol/issues/10
 
+  if RUBY_VERSION < '3.1'
+    # https://github.com/ruby/net-protocol/issues/10
+    # https://github.com/rails/rails/pull/44175
+    spec.add_runtime_dependency 'net-http', '~> 0.2.2'
+  end
   spec.add_development_dependency 'pg'
   spec.add_development_dependency 'rails', '>= 6.0'
   spec.add_development_dependency 'factory_bot', '~> 6.2', '>= 6.2.1'


### PR DESCRIPTION
When running any rails command on a Rails App (v7) Ruby (2.7.4) with ActiveStash installed, these warning messages output.

```
/Users/fionamccawley/.asdf/installs/ruby/2.7.4/lib/ruby/2.7.0/net/protocol.rb:66: warning: already initialized constant Net::ProtocRetryError
/Users/fionamccawley/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/net-protocol-0.1.3/lib/net/protocol.rb:68: warning: previous definition of ProtocRetryError was here
/Users/fionamccawley/.asdf/installs/ruby/2.7.4/lib/ruby/2.7.0/net/protocol.rb:206: warning: already initialized constant Net::BufferedIO::BUFSIZE
```

This previous PR added `net-http` as a dev dependancy to try fix this. https://github.com/cipherstash/activestash/pull/33. And was released as part of version 0.4.1.

When testing i'm still seeing these warning messages. Changing the dep to be a runtime dependancy in ActiveStash fixes the issue for me.

This fix is based off the below link. 

https://github.com/rails/rails/pull/44175

It looks like the issue is to do with net-protocol being loaded twice, as a gem and as a Ruby library. This issue has a good explanation of what is happening. https://github.com/rails/rails/pull/44175#issue-1104064625

I tested with a Rails 7 app with Ruby 3.1 with active stash installed, and do not see the issue.

When running the activestash CI tests, this error was being returned for Ruby versions 2.7.4. This is because uri version 0.10.0 is a default gem with Ruby 2.7, but net-http has uri 0.11.0 as a dependancy. https://rubygems.org/gems/net-http/versions/0.2.2/dependencies

In version 3.1 onwards the default uri version is 0.11.0. https://stdgems.org/uri/.

Setting 0.11.0 as the default gem resolved this issue in our CI tests. I'm not seeing this error in this[ Rails Test app though](https://github.com/fimac/ActiveStashDeployApp), when running any bundle exec commands.

```
bundler: failed to load command: rake (/home/runner/work/activestash/activestash/vendor/bundle/ruby/2.7.0/bin/rake)
/opt/hostedtoolcache/Ruby/2.7.6/x64/lib/ruby/gems/2.7.0/gems/bundler-2.3.16/lib/bundler/runtime.rb:309:in `check_for_activated_spec!': You have already activated uri 0.10.0, but your Gemfile requires uri 0.11.0. Since uri is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports uri as a default gem. (Gem::LoadError)
```



_Testing done_

Pull down this branch.

Run bundle install.

[Using this test rails app](https://github.com/fimac/ActiveStashDeployApp) with active stash installed, run bundle install, then run any rails command, eg. `rails c`.

Should see the above warnings.

Update the active_stash gem to point to your local active stash repo.

`gem "active_stash", path: "/Users/fionamccawley/cipherstash/activestash"`

Run bundle install with the test rails app.

Run `rails c` again, and no output should display.



