### PR TITLE
Provide helpful error message when regexp passed to =~

### DIFF
--- a/lib/active_stash/query_builder.rb
+++ b/lib/active_stash/query_builder.rb
@@ -81,8 +81,15 @@ module ActiveStash
       end
 
       def =~(value)
-        @op ||= :match
-        set(value)
+        case value
+        when ::String
+          @op ||= :match
+          set(value)
+        when ::Regexp
+          ::Kernel.raise ::ActiveStash::QueryError, "regular expressions are not yet supported for matching"
+        else
+          ::Kernel.raise ::ActiveStash::QueryError, "unknown value type passed to =~: #{value.inspect}"
+        end
       end
 
       def >(value)

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -91,6 +91,14 @@ RSpec.describe "ActiveStash::Search.query" do
     end
   end
 
+  describe "#query match" do
+    it "raises error if trying to match a regex" do
+      expect do
+        User.query { |q| q.first_name =~ /Mel/ }
+      end.to raise_error(ActiveStash::QueryError, /regular expressions/)
+    end
+  end
+
   describe "limit and offset" do
     it "by exact gender (limit=5)" do
       expect(User.query(gender: "F").limit(4).length).to eq(4)


### PR DESCRIPTION
We want to support regex matching, but we're not quite there yet.