### PR TITLE
Use correct id attribute name to fix queries

### DIFF
--- a/lib/active_stash/relation.rb
+++ b/lib/active_stash/relation.rb
@@ -67,7 +67,7 @@ module ActiveStash
               *constraint.values
             )
           end
-        end.records.map(&:id)
+        end.records.map(&:uuid)
 
         relation = @scope.where(stash_id: ids)
         relation = relation.in_order_of(:stash_id, ids) if @stash_order


### PR DESCRIPTION
At some point the ruby-client changed which broke ActiveStash. This fixes it.