### PR TITLE
Bump cipherstash-client to v0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Bump min cipherstash-client version to v0.14 (includes filter indexes and bug fixes)
+
 ## [0.4.4]
 
 ### Changed
@@ -66,4 +70,3 @@ Indexing now ignores `json`, `jsonb` and `uuid` types. These may be added later.
 ## [0.1.1]
 
 First public release
-

--- a/activestash.gemspec
+++ b/activestash.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.metadata["documentation_uri"] = "https://rubydoc.info/gems/active_stash"
   spec.metadata["mailing_list_uri"] = "https://discuss.cipherstash.com"
 
-  spec.add_runtime_dependency "cipherstash-client", "~> 0.12"
+  spec.add_runtime_dependency "cipherstash-client", "~> 0.14"
   spec.add_runtime_dependency "activerecord"
   spec.add_runtime_dependency "terminal-table", "~> 3.0"
   spec.add_runtime_dependency "launchy", "~> 2.5"


### PR DESCRIPTION
This PR bumps the min `cipherstash-client` version to v0.14 (includes filter indexes and bug fixes).