### PR TITLE
Load models correctly

### DIFF
--- a/lib/tasks/active_stash.rake
+++ b/lib/tasks/active_stash.rake
@@ -4,7 +4,7 @@ require "terminal-table"
 require "launchy"
 
 def stash_enabled_models
-  Dir.glob("#{Rails.root}/app/models/*.rb").each { |file| require file }
+  Dir.glob("#{Rails.root}/app/models/*.rb").each { |file| Module.const_get("::" + File.basename(file, ".rb").camelize) }
   ActiveRecord::Base.descendants.select do |m|
     if m.respond_to?(:is_stash_model?) && block_given?
       yield m


### PR DESCRIPTION
Some models don't react well to being loaded more than once, but ActiveRecord does a very poor job of avoiding duplicate loading.
So we've got to slum it somewhat and trip the dependency loader to make sure they're only getting loaded once.