### PR TITLE
Add ability to specify a unique constraint on exact and range indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ To use, include ActiveStash::Search in a model and define which fields you want 
 class User < ActiveRecord::Base
   include ActiveStash::Search
 
+  # Searchable fields
   stash_index :name, :email, :dob
 
   # fields encrypted with EncryptedRecord
@@ -246,6 +247,49 @@ User.query("ruby")
 
 For more information on index types and their options, see the [CipherStash
 docs](https://docs.cipherstash.com/reference/index-types/index.html).
+
+## Unique indexes
+
+ActiveStash supports adding server side unique constraints on `:range` and `:exact` indexes.
+
+Unique constraints are not supported on `:match` indexes.
+
+To specify a unique constraint on a field add `unique: true`.
+
+In the below example a unique constraint is added to the email field.
+
+This will result in a `:match` index and a unique constraint on the `:range` and `:exact` indexes.
+
+```ruby
+class User < ActiveRecord::Base
+  include ActiveStash::Search
+
+  stash_index :name, :dob
+  stash_index :email, unique: true
+
+  encrypts :name
+  encrypts :email
+  encrypts :dob
+end
+```
+
+Used in combination with `except` and `only` you can specify a unique constraint on a
+single index.
+
+In the below example, an exact index on email is created with a unique constraint
+
+```ruby
+stash_index :email, only: :exact, unique: true
+```
+
+ActiveStash does not support unique constraints on `:match` indexes.
+
+The below example will result in a `ConfigError` being raised.
+
+```ruby
+stash_index :email, only: :match, unique: true
+```
+
 
 ## Create a CipherStash Collection
 

--- a/README.md
+++ b/README.md
@@ -250,15 +250,11 @@ docs](https://docs.cipherstash.com/reference/index-types/index.html).
 
 ## Unique indexes
 
-ActiveStash supports adding server side unique constraints on `:range` and `:exact` indexes.
+ActiveStash supports adding server side unique constraints on fields.
 
-Unique constraints are not supported on `:match` indexes.
-
-To specify a unique constraint on a field add `unique: true`.
+Unique fields can be specified by adding `unique: true`.
 
 In the below example a unique constraint is added to the email field.
-
-This will result in a `:match` index and a unique constraint on the `:range` and `:exact` indexes.
 
 ```ruby
 class User < ActiveRecord::Base
@@ -273,16 +269,7 @@ class User < ActiveRecord::Base
 end
 ```
 
-Used in combination with `except` and `only` you can specify a unique constraint on a
-single index.
-
-In the below example, an exact index on email is created with a unique constraint
-
-```ruby
-stash_index :email, only: :exact, unique: true
-```
-
-ActiveStash does not support unique constraints on `:match` indexes.
+ActiveStash does not support adding unique constraints on `:match` indexes.
 
 The below example will result in a `ConfigError` being raised.
 

--- a/activestash.gemspec
+++ b/activestash.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.metadata["documentation_uri"] = "https://rubydoc.info/gems/active_stash"
   spec.metadata["mailing_list_uri"] = "https://discuss.cipherstash.com"
 
-  spec.add_runtime_dependency "cipherstash-client", "~> 0.15"
+  spec.add_runtime_dependency "cipherstash-client", "~> 0.15.1"
   spec.add_runtime_dependency "activerecord"
   spec.add_runtime_dependency "terminal-table", "~> 3.0"
   spec.add_runtime_dependency "launchy", "~> 2.5"

--- a/activestash.gemspec
+++ b/activestash.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.metadata["documentation_uri"] = "https://rubydoc.info/gems/active_stash"
   spec.metadata["mailing_list_uri"] = "https://discuss.cipherstash.com"
 
-  spec.add_runtime_dependency "cipherstash-client", "~> 0.12"
+  spec.add_runtime_dependency "cipherstash-client", "~> 0.15"
   spec.add_runtime_dependency "activerecord"
   spec.add_runtime_dependency "terminal-table", "~> 3.0"
   spec.add_runtime_dependency "launchy", "~> 2.5"

--- a/lib/active_stash/schema_builder.rb
+++ b/lib/active_stash/schema_builder.rb
@@ -28,6 +28,12 @@ module ActiveStash
 
             when :dynamic_match
               dynamic_match!(indexes, index)
+            
+            when :range_unique
+              range_unique_index!(indexes, index)
+            
+            when :exact_unique
+              exact_unique_index!(indexes, index)
           end
         end
       end
@@ -82,10 +88,30 @@ module ActiveStash
       schema
     end
 
+    def range_unique_index!(schema, index)
+      schema[index.name] = {
+        "kind" => "range",
+        "field" => index.field,
+        "unique" => true
+      }
+
+      schema
+    end
+
     def exact_index!(schema, index)
       schema[index.name] = {
         "kind" => "exact",
-        "field" => index.field
+        "field" => index.field,
+      }
+
+      schema
+    end
+
+    def exact_unique_index!(schema, index)
+      schema[index.name] = {
+        "kind" => "exact",
+        "field" => index.field,
+        "unique" => true
       }
 
       schema

--- a/lib/active_stash/schema_builder.rb
+++ b/lib/active_stash/schema_builder.rb
@@ -28,12 +28,6 @@ module ActiveStash
 
             when :dynamic_match
               dynamic_match!(indexes, index)
-            
-            when :range_unique
-              range_unique_index!(indexes, index)
-            
-            when :exact_unique
-              exact_unique_index!(indexes, index)
           end
         end
       end
@@ -80,39 +74,39 @@ module ActiveStash
     end
 
     def range_index!(schema, index)
-      schema[index.name] = {
+      mapping = {
         "kind" => "range",
         "field" => index.field
       }
 
-      schema
-    end
+      if index.unique
+        mapping = {
+          "kind" => "range",
+          "field" => index.field,
+          "unique" => index.unique
+        }
+      end
 
-    def range_unique_index!(schema, index)
-      schema[index.name] = {
-        "kind" => "range",
-        "field" => index.field,
-        "unique" => true
-      }
+      schema[index.name] = mapping
 
       schema
     end
 
     def exact_index!(schema, index)
-      schema[index.name] = {
+      mapping = {
         "kind" => "exact",
-        "field" => index.field,
+        "field" => index.field
       }
 
-      schema
-    end
+      if index.unique
+        mapping = {
+          "kind" => "range",
+          "field" => index.field,
+          "unique" => index.unique
+        }
+      end
 
-    def exact_unique_index!(schema, index)
-      schema[index.name] = {
-        "kind" => "exact",
-        "field" => index.field,
-        "unique" => true
-      }
+      schema[index.name] = mapping
 
       schema
     end

--- a/lib/active_stash/stash_indexes.rb
+++ b/lib/active_stash/stash_indexes.rb
@@ -1,6 +1,6 @@
 module ActiveStash
   class Index
-    attr_accessor :type, :valid_ops
+    attr_accessor :type, :valid_ops, :unique
     attr_reader :field
     attr_reader :name
 
@@ -29,6 +29,14 @@ module ActiveStash
       end
     end
 
+    def self.exact_unique(field)
+      new(field).tap do |index|
+        index.type = :exact
+        index.valid_ops = [:eq]
+        index.unique = true
+      end
+    end
+
     def self.match(field)
       new(field, "#{field}_match").tap do |index|
         index.type = :match
@@ -50,22 +58,18 @@ module ActiveStash
       end
     end
 
+    def self.range_unique(field)
+      new(field, "#{field}_range").tap do |index|
+        index.type = :range
+        index.valid_ops = RANGE_OPS
+        index.unique = true
+      end
+    end
+
     def self.dynamic_match(field)
       new(field, "#{field}_dynamic_match").tap do |index|
         index.type = :dynamic_match
         index.valid_ops = [:match]
-      end
-    end
-
-    def self.range_unique(field)
-      new(field, "#{field}_range_unique").tap do |index|
-        index.type = :range_unique
-      end
-    end
-
-    def self.exact_unique(field)
-      new(field, "#{field}_unique").tap do |index|
-        index.type = :exact_unique
       end
     end
 

--- a/spec/active_stash/unique_indexes_spec.rb
+++ b/spec/active_stash/unique_indexes_spec.rb
@@ -13,8 +13,8 @@ end
 
 RSpec::Matchers.define :have_an_exact_unique_index do |name|
   match do |actual|
-    target = actual.find { |i| i.type == :exact_unique }
-    !target.nil? && target.name == name
+    target = actual.find { |i| i.type == :exact}
+    !target.nil? && target.name == name && target.unique == true
   end
 end
 
@@ -27,8 +27,8 @@ end
 
 RSpec::Matchers.define :have_a_range_unique_index do |name|
   match do |actual|
-    target = actual.find { |i| i.type == :range_unique }
-    !target.nil? && target.name == name
+    target = actual.find { |i| i.type == :range }
+    !target.nil? && target.name == name  && target.unique == true
   end
 end
 
@@ -57,7 +57,7 @@ RSpec.describe ActiveStash::StashIndexes do
       expect(subject.length).to eq(1)
     end
 
-    it { should have_an_exact_unique_index("first_name_unique") }
+    it { should have_an_exact_unique_index("first_name") }
   end
 
   describe "email with a match and a unique constraint on range and exact" do
@@ -67,8 +67,8 @@ RSpec.describe ActiveStash::StashIndexes do
       expect(subject.length).to eq(3)
     end
 
-    it { should have_an_exact_unique_index("email_unique") }
-    it { should have_a_range_unique_index("email_range_unique") }
+    it { should have_an_exact_unique_index("email") }
+    it { should have_a_range_unique_index("email_range") }
     it { should have_a_match_index("email_match") }
   end
 

--- a/spec/active_stash/unique_indexes_spec.rb
+++ b/spec/active_stash/unique_indexes_spec.rb
@@ -1,0 +1,92 @@
+require_relative "../support/user_unique_indexes"
+require_relative "../support/user_invalid_unique_indexes"
+require_relative "../support/migrations/create_users2"
+
+require 'rspec/expectations'
+
+RSpec::Matchers.define :have_an_exact_index do |name|
+  match do |actual|
+    target = actual.find { |i| i.type == :exact }
+    !target.nil? && target.name == name
+  end
+end
+
+RSpec::Matchers.define :have_an_exact_unique_index do |name|
+  match do |actual|
+    target = actual.find { |i| i.type == :exact_unique }
+    !target.nil? && target.name == name
+  end
+end
+
+RSpec::Matchers.define :have_a_range_index do |name|
+  match do |actual|
+    target = actual.find { |i| i.type == :range }
+    !target.nil? && target.name == name
+  end
+end
+
+RSpec::Matchers.define :have_a_range_unique_index do |name|
+  match do |actual|
+    target = actual.find { |i| i.type == :range_unique }
+    !target.nil? && target.name == name
+  end
+end
+
+RSpec::Matchers.define :have_a_match_index do |name|
+  match do |actual|
+    target = actual.find { |i| i.type == :match }
+    !target.nil? && target.name == name
+  end
+end
+
+RSpec.describe ActiveStash::StashIndexes do
+  before(:all) do
+    CreateUsers2.migrate(:up)
+  end
+
+  after(:all) do
+    CreateUsers2.migrate(:down)
+  end
+
+  let(:indexes) { UserUniqueIndexes.stash_indexes }
+
+  describe "first_name with unique exact" do
+    subject { indexes.on(:first_name) }
+
+    it "has 1 index defined" do
+      expect(subject.length).to eq(1)
+    end
+
+    it { should have_an_exact_unique_index("first_name_unique") }
+  end
+
+  describe "email with a match and a unique constraint on range and exact" do
+    subject { indexes.on(:email)}
+
+    it "has 3 indexes defined" do
+      expect(subject.length).to eq(3)
+    end
+
+    it { should have_an_exact_unique_index("email_unique") }
+    it { should have_a_range_unique_index("email_range_unique") }
+    it { should have_a_match_index("email_match") }
+  end
+
+  describe "last_name without a unique constraint specified" do
+    subject { indexes.on(:last_name)}
+
+    it "has 3 indexes defined" do
+      expect(subject.length).to eq(3)
+    end
+
+    it { should have_an_exact_index("last_name") }
+    it { should have_a_range_index("last_name_range") }
+    it { should have_a_match_index("last_name_match") }
+  end
+
+  describe "invalid unique constraints" do
+    it "unique on a match field should raise a config error" do
+        expect { UserInvalidUniqueIndexes.stash_indexes }.to raise_error(ActiveStash::ConfigError)
+    end
+  end
+end

--- a/spec/put_spec.rb
+++ b/spec/put_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "ActiveStash::Search.cs_put" do
           title: "Ms",
           email: "smeyer@veep.net"
         )
-      end.to raise_error(CipherStash::Client::Error::RecordPutFailure)
+      end.to raise_error(CipherStash::Client::Error::RecordPutError)
     end
 
     it "an error will be raised if the email is in a different case" do
@@ -102,7 +102,7 @@ RSpec.describe "ActiveStash::Search.cs_put" do
           title: "Ms",
           email: "SMEyer@Veep.net"
         )
-      end.to raise_error(CipherStash::Client::Error::RecordPutFailure)
+      end.to raise_error(CipherStash::Client::Error::RecordPutError)
     end
 
     it "does not raise an error if the email is not a duplicate" do

--- a/spec/put_spec.rb
+++ b/spec/put_spec.rb
@@ -1,5 +1,7 @@
 require_relative "support/user"
+require_relative "support/user_unique_indexes"
 require_relative "support/migrations/create_users"
+require_relative "support/migrations/create_users2"
 
 RSpec.describe "ActiveStash::Search.cs_put" do
   describe "#cs_put" do
@@ -21,7 +23,7 @@ RSpec.describe "ActiveStash::Search.cs_put" do
         dob: "Aug 3, 1963",
         created_at: 10.days.ago,
         title: "Mr",
-        email: "james@metalica.net"
+        email: "james@metallica.net"
       )
     end
 
@@ -36,5 +38,95 @@ RSpec.describe "ActiveStash::Search.cs_put" do
       expect(user.stash_id).not_to be_nil
     end
   end
-end
 
+  describe "#cs_put with unique cs indexes with a unique constraint on email" do
+    before(:all) do
+      CreateUsers2.migrate(:up)
+    end
+
+    after(:all) do
+      CreateUsers2.migrate(:down)
+    end
+
+    before(:each) do
+      UserUniqueIndexes.collection.create!
+    end
+
+    after(:each) do
+      UserUniqueIndexes.delete_all
+      UserUniqueIndexes.collection.drop!
+    end
+
+    it "should raise an error on insert of duplicate" do
+      UserUniqueIndexes.create!(
+        first_name: "Selina",
+        last_name: "Meyer",
+        gender: "F",
+        dob: "Jan 1, 1961",
+        created_at: 10.days.ago,
+        title: "Ms",
+        email: "smeyer@veep.net"
+      )
+
+      expect do
+        UserUniqueIndexes.create!(
+          first_name: "Serena",
+          last_name: "Meyer",
+          gender: "F",
+          dob: "Jan 1, 1962",
+          created_at: 10.days.ago,
+          title: "Ms",
+          email: "smeyer@veep.net"
+        )
+      end.to raise_error(CipherStash::Client::Error::RecordPutFailure)
+    end
+
+    it "an error will be raised if the email is in a different case" do
+      UserUniqueIndexes.create!(
+        first_name: "Selina",
+        last_name: "Meyer",
+        gender: "F",
+        dob: "Jan 1, 1961",
+        created_at: 10.days.ago,
+        title: "Ms",
+        email: "smeyer@veep.net"
+      )
+
+      expect do
+        UserUniqueIndexes.create!(
+          first_name: "Serena",
+          last_name: "Meyer",
+          gender: "F",
+          dob: "Jan 1, 1962",
+          created_at: 10.days.ago,
+          title: "Ms",
+          email: "SMEyer@Veep.net"
+        )
+      end.to raise_error(CipherStash::Client::Error::RecordPutFailure)
+    end
+
+    it "does not raise an error if the email is not a duplicate" do
+       UserUniqueIndexes.create!(
+        first_name: "Selina",
+        last_name: "Meyer",
+        gender: "F",
+        dob: "Jan 1, 1961",
+        created_at: 10.days.ago,
+        title: "Ms",
+        email: "smeyer@veep.net"
+      )
+
+      expect do
+        UserUniqueIndexes.create!(
+          first_name: "Serena",
+          last_name: "Meyer",
+          gender: "F",
+          dob: "Jan 1, 1962",
+          created_at: 10.days.ago,
+          title: "Ms",
+          email: "smeyers@veep.net"
+        )
+      end.not_to raise_error()
+    end
+  end
+end

--- a/spec/support/user_invalid_unique_indexes.rb
+++ b/spec/support/user_invalid_unique_indexes.rb
@@ -1,0 +1,18 @@
+class UserInvalidUniqueIndexes < ActiveRecord::Base
+  include ActiveStash::Search
+  self.table_name = "users2"
+  self.collection_name = "activestash_test_#{ENV["ACTIVE_STASH_TEST_COLLECTION_PREFIX"] || ""}_users2"
+
+  stash_index :first_name, except: [:match, :range], unique: true
+  stash_index :dob
+  stash_index :gender, only: :exact
+  stash_index :title, except: [:match, :range]
+  stash_index :created_at, :updated_at, except: :range
+
+  stash_index :email, unique: true
+
+  # Invalid unique constraint on match
+  stash_index :last_name, only: :match, unique: true
+
+  stash_match_all :first_name, :email
+end

--- a/spec/support/user_unique_indexes.rb
+++ b/spec/support/user_unique_indexes.rb
@@ -1,0 +1,15 @@
+class UserUniqueIndexes < ActiveRecord::Base
+  include ActiveStash::Search
+  self.table_name = "users2"
+  self.collection_name = "activestash_test_#{ENV["ACTIVE_STASH_TEST_COLLECTION_PREFIX"] || ""}_users2"
+
+  stash_index :first_name, except: [:match, :range], unique: true
+  stash_index :dob, :last_name
+  stash_index :gender, only: :exact
+  stash_index :title, except: [:match, :range]
+  stash_index :created_at, :updated_at, except: :range
+
+  stash_index :email, unique: true
+
+  stash_match_all :first_name, :email
+end


### PR DESCRIPTION
This PR updates:
- stash indexes and the schema builder to handle the ability specify a unique constraint on range and exact indexes.
- Raises an error if a unique constraint is specified on a match index.
- Tests to cover the above and check if an error is raised when a duplicate record is inserted.
- I also added a test to check to see if case sensitivity made a difference. A RecordPutFailure will still be raised even if the field is in a different case.
- Updates readme.
