### PR TITLE
Remove bundler gem helpers to avoid conflict with git release task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ Gemfile.lock
 # rspec failure tracking
 .rspec_status
 /.envrc
-*.gem

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Gemfile.lock
 # rspec failure tracking
 .rspec_status
 /.envrc
+*.gem

--- a/README.md
+++ b/README.md
@@ -551,11 +551,11 @@ Then, run `rake spec` to run the tests. You can also run `bin/console` for an in
 
 To install this gem onto your local machine:
 
-1. Build the gem by running `gem build activestash.gemspec`.
+1. Build the gem by running `rake gem`.
 
-2. This will create a gem file (`active_stash-x.x.x.gem`) in the root of this directory
+2. This will create a gem file (`active_stash-x.x.x.gem`) in the `./pkg` folder.
 
-2. Install the gem by running `gem install` with the gem file name, e.g `gem install active_stash-x.x.x.gem`
+3. Install the gem by running `gem install` with the gem file name, e.g `gem install ./pkg/active_stash-x.x.x.gem`
 
 ## Making a Release
 

--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ If you have push access to the GitHub repository, you can make a release by doin
    Save/exit your editor.
    This will automatically push the newly-created annotated tag, which will in turn kick off a release build of the gem and push it to [RubyGems.org](https://rubygems.org/gems/active_stash).
 
-3. Run `rake git_release` to automagically create a new [GitHub release](https://github.com/cipherstash/activestash/releases) for the project.
+3. Run `rake release` to automagically create a new [GitHub release](https://github.com/cipherstash/activestash/releases) for the project.
 
 ... and that's it!
 

--- a/README.md
+++ b/README.md
@@ -549,7 +549,13 @@ The test suite depends on a running postgres instance being available on localho
 
 Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`.
+To install this gem onto your local machine:
+
+1. Build the gem by running `gem build activestash.gemspec`.
+
+2. This will create a gem file (`active_stash-x.x.x.gem`) in the root of this directory
+
+2. Install the gem by running `gem install` with the gem file name, e.g `gem install active_stash-x.x.x.gem`
 
 ## Making a Release
 

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ If you have push access to the GitHub repository, you can make a release by doin
    Save/exit your editor.
    This will automatically push the newly-created annotated tag, which will in turn kick off a release build of the gem and push it to [RubyGems.org](https://rubygems.org/gems/active_stash).
 
-3. Run `rake release` to automagically create a new [GitHub release](https://github.com/cipherstash/activestash/releases) for the project.
+3. Run `rake git_release` to automagically create a new [GitHub release](https://github.com/cipherstash/activestash/releases) for the project.
 
 ... and that's it!
 

--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,6 @@ namespace :gem do
   end
 end
 
-task :release do
+task :git_release do
   sh "git release"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 exec(*(["bundle", "exec", $PROGRAM_NAME] + ARGV)) if ENV['BUNDLE_GEMFILE'].nil?
 
-require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
@@ -21,6 +20,6 @@ namespace :gem do
   end
 end
 
-task :git_release do
+task :release do
   sh "git release"
 end


### PR DESCRIPTION
When running `rake release` the imported bundler gem release task is called instead of the git release task in the rakefile.

<img width="553" alt="Screen Shot 2022-08-15 at 7 02 28 pm" src="https://user-images.githubusercontent.com/26052576/184607338-dc915152-26ce-46da-b2d8-634460130745.png">

This is because we import `require "bundler/gem_tasks"` in the rake file. We do currently use a task from this import, `bundle exec rake install` to install a local version of the gem. 

This PR updates the name of the git release task to differentiate it from the bundler gem task, and updates the reference in the readme.

