### PR TITLE
Add basic count implementation

### DIFF
--- a/lib/active_stash/relation.rb
+++ b/lib/active_stash/relation.rb
@@ -4,8 +4,7 @@ module ActiveStash
   class Relation < ::ActiveRecord::Relation
     include ActiveStash::RelationHelp::Compatability
 
-    # TODO: Add count aggregate support
-    stash_unsupported(:where, :count, :delete_all, :destroy_all)
+    stash_unsupported(:where, :delete_all, :destroy_all)
     stash_wrap(:select, :all, :includes, :joins, :annotate)
 
     delegate :name, :inspect, to: :@scope
@@ -44,6 +43,14 @@ module ActiveStash
     def last(n = nil)
       if stash_query?
         n ? self.load.last(n) : self.load.last
+      else
+        super
+      end
+    end
+
+    def count
+      if stash_query?
+        self.load.count
       else
         super
       end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -194,4 +194,46 @@ RSpec.describe "ActiveStash::Search.query" do
       expect(result).to match([match(%r{\A\h{8}(-\h{4}){3}-\h{12}\z})])
     end
   end
+
+  describe "#count" do
+    it "can be chained with simple queries" do
+      count = User.query(gender: "F").count
+
+      expect(count).to eq(5)
+    end
+
+    it "can be chained with queries with blocks" do
+      count = User.query { |q|
+        q.dob.between("1974-01-12".to_date, "1974-06-17".to_date)
+      }.count
+
+      expect(count).to eq(2)
+    end
+
+    it "can be chained with wrapped methods" do
+      count = User.query { |q|
+        q.dob.between("1974-01-12".to_date, "1974-06-17".to_date)
+      }.select(:first_name).count
+
+      expect(count).to eq(2)
+    end
+
+    it "can be chained when order is given" do
+      count = User.query(gender: "F").order(dob: :desc).count
+
+      expect(count).to eq(5)
+    end
+
+    it "can be chained with limit and offset" do
+      count = User.query(gender: "F").limit(3).offset(4).count
+
+      expect(count).to eq(1)
+    end
+
+    it "still works without an ActiveStash query" do
+      count = ActiveStash::Relation.new(User).count
+
+      expect(count).to eq(9)
+    end
+  end
 end


### PR DESCRIPTION
This change adds a basic implementation of the count method on `ActiveStash::Relation`. This is implemented by loading all records and then counting the number of results in memory.

This implementation can be replaced with a proper aggregate query once they're supported in StashRB.