### PR TITLE
Fix path to Rake tasks in Railtie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+* Fixed a bug where Rake tasks would not load correctly if users had a `tasks/active_stash.rake` file defined within a project.
+
 ## [0.7.0]
 
 * Added basic support for counts on `ActiveStash::Relation`

--- a/lib/active_stash/railtie.rb
+++ b/lib/active_stash/railtie.rb
@@ -30,7 +30,8 @@ module ActiveStash
     end
 
     rake_tasks do
-      load "tasks/active_stash.rake"
+      path = File.expand_path(File.join(__dir__, "../tasks/active_stash.rake"))
+      load path
     end
   end
 


### PR DESCRIPTION
This fixes a bug where users could accidentally clobber the ActiveStash
Rake tasks.

The path used for loading Rake tasks in the Railtie used an implicit
relative path. This would cause Kernel.load to attempt to load the file
based on $LOAD_PATH. Usually this wouldn't cause any issues, but
this would load `lib/tasks/active_stash.rake` in the user's project if
they happened to have it defined. This means that the actual Rake
tasks for ActiveStash would never be loaded an instead would be
clobbered by the user's `active_stash.rake` file.

Using an absolute path ensures that users can't accidentally clobber
the Rake tasks provided by ActiveStash.

See: https://ruby-doc.org/core-3.1.2/Kernel.html#method-i-load