### PR TITLE
check if attribute is encrypted before checking type and add test

### DIFF
--- a/lib/active_stash/stash_indexes.rb
+++ b/lib/active_stash/stash_indexes.rb
@@ -157,7 +157,7 @@ module ActiveStash
 
     def fields
       fields = @model.attribute_types.inject({}) do |attrs, (k,v)|
-        type = v.class.name == "ActiveRecord::Encryption::EncryptedAttributeType" ? v.cast_type.type : v.type
+        type = ActiveRecord::Encryption::EncryptedAttributeType === v ? v.cast_type.type : v.type
         attrs.tap { |a| a[k] = type }
       end
       handle_encrypted_types(fields)

--- a/lib/active_stash/stash_indexes.rb
+++ b/lib/active_stash/stash_indexes.rb
@@ -157,7 +157,13 @@ module ActiveStash
 
     def fields
       fields = @model.attribute_types.inject({}) do |attrs, (k,v)|
-        type = ActiveRecord::Encryption::EncryptedAttributeType === v ? v.cast_type.type : v.type
+        type = v.type
+
+        # ActiveRecord encryption is available from Rails 7.
+        if Rails::VERSION::MAJOR >= 7
+          type = ActiveRecord::Encryption::EncryptedAttributeType === v ? v.cast_type.type : v.type
+        end
+
         attrs.tap { |a| a[k] = type }
       end
       handle_encrypted_types(fields)

--- a/lib/active_stash/stash_indexes.rb
+++ b/lib/active_stash/stash_indexes.rb
@@ -157,7 +157,8 @@ module ActiveStash
 
     def fields
       fields = @model.attribute_types.inject({}) do |attrs, (k,v)|
-        attrs.tap { |a| a[k] = v.type }
+        type = v.class.name == "ActiveRecord::Encryption::EncryptedAttributeType" ? v.cast_type.type : v.type
+        attrs.tap { |a| a[k] = type }
       end
       handle_encrypted_types(fields)
     end

--- a/spec/active_stash/active_record_encryption_spec.rb
+++ b/spec/active_stash/active_record_encryption_spec.rb
@@ -1,0 +1,79 @@
+require_relative "../support/user4"
+require_relative "../support/migrations/create_users4"
+
+require 'rspec/expectations'
+
+RSpec::Matchers.define :have_an_exact_index do |name|
+  match do |actual|
+    target = actual.find { |i| i.type == :exact }
+    !target.nil? && target.name == name
+  end
+end
+
+RSpec::Matchers.define :have_a_range_index do |name|
+  match do |actual|
+    target = actual.find { |i| i.type == :range }
+    !target.nil? && target.name == name
+  end
+end
+
+RSpec::Matchers.define :have_a_match_index do |name|
+  match do |actual|
+    target = actual.find { |i| i.type == :match }
+    !target.nil? && target.name == name
+  end
+end
+
+RSpec.describe ActiveStash::StashIndexes do
+  before(:all) do
+    CreateUsers4.migrate(:up)
+  end
+
+  after(:all) do
+    CreateUsers4.migrate(:down)
+  end
+
+  let(:indexes) { User4.stash_indexes }
+
+  describe "first_name" do
+    subject { indexes.on(:first_name) }
+
+    it "has 3 indexes defined" do
+      expect(subject.length).to eq(3)
+    end
+
+    it { should have_an_exact_index("first_name") }
+    it { should have_a_range_index("first_name_range") }
+    it { should have_a_match_index("first_name_match") }
+  end
+
+  describe "boolean types" do
+    subject { indexes.on(:verified) }
+
+    it "has 1 index defined" do
+      expect(subject.length).to eq(1)
+    end
+
+    it { should have_an_exact_index("verified") }
+  end
+
+  describe "date types" do
+    subject { indexes.on(:dob) }
+
+    it "has 1 index defined" do
+      expect(subject.length).to eq(1)
+    end
+
+    it { should have_a_range_index("dob_range") }
+  end
+
+  describe "float types" do
+    subject { indexes.on(:latitude) }
+
+    it "has 1 index defined" do
+      expect(subject.length).to eq(1)
+    end
+
+    it { should have_a_range_index("latitude_range") }
+  end
+end

--- a/spec/active_stash/active_record_encryption_spec.rb
+++ b/spec/active_stash/active_record_encryption_spec.rb
@@ -1,79 +1,62 @@
 require_relative "../support/user4"
 require_relative "../support/migrations/create_users4"
-
+require_relative "../spec_helper.rb"
 require 'rspec/expectations'
 
-RSpec::Matchers.define :have_an_exact_index do |name|
-  match do |actual|
-    target = actual.find { |i| i.type == :exact }
-    !target.nil? && target.name == name
-  end
-end
+# ActiveRecord Encryption is only available from Rails 7.
 
-RSpec::Matchers.define :have_a_range_index do |name|
-  match do |actual|
-    target = actual.find { |i| i.type == :range }
-    !target.nil? && target.name == name
-  end
-end
-
-RSpec::Matchers.define :have_a_match_index do |name|
-  match do |actual|
-    target = actual.find { |i| i.type == :match }
-    !target.nil? && target.name == name
-  end
-end
-
-RSpec.describe ActiveStash::StashIndexes do
-  before(:all) do
-    CreateUsers4.migrate(:up)
-  end
-
-  after(:all) do
-    CreateUsers4.migrate(:down)
-  end
-
-  let(:indexes) { User4.stash_indexes }
-
-  describe "first_name" do
-    subject { indexes.on(:first_name) }
-
-    it "has 3 indexes defined" do
-      expect(subject.length).to eq(3)
+if Rails::VERSION::MAJOR >= 7
+  RSpec.describe ActiveStash::StashIndexes do
+    before(:all) do
+      CreateUsers4.migrate(:up)
     end
 
-    it { should have_an_exact_index("first_name") }
-    it { should have_a_range_index("first_name_range") }
-    it { should have_a_match_index("first_name_match") }
-  end
-
-  describe "boolean types" do
-    subject { indexes.on(:verified) }
-
-    it "has 1 index defined" do
-      expect(subject.length).to eq(1)
+    after(:all) do
+      CreateUsers4.migrate(:down)
     end
 
-    it { should have_an_exact_index("verified") }
-  end
+    let(:indexes) { User4.stash_indexes }
 
-  describe "date types" do
-    subject { indexes.on(:dob) }
+    describe "first_name" do
+      subject { indexes.on(:first_name) }
 
-    it "has 1 index defined" do
-      expect(subject.length).to eq(1)
+      it "has 3 indexes defined" do
+        expect(subject.length).to eq(3)
+      end
+
+      it { should have_an_exact_index("first_name") }
+      it { should have_a_range_index("first_name_range") }
+      it { should have_a_match_index("first_name_match") }
     end
 
-    it { should have_a_range_index("dob_range") }
-  end
+    describe "boolean types" do
+      subject { indexes.on(:verified) }
 
-  describe "float types" do
-    subject { indexes.on(:latitude) }
+      it "has 1 index defined" do
+        expect(subject.length).to eq(1)
+      end
 
-    it "has 1 index defined" do
-      expect(subject.length).to eq(1)
+      it { should have_an_exact_index("verified") }
     end
 
-    it { should have_a_range_index("latitude_range") }
+    describe "date types" do
+      subject { indexes.on(:dob) }
+
+      it "has 1 index defined" do
+        expect(subject.length).to eq(1)
+      end
+
+      it { should have_a_range_index("dob_range") }
+    end
+
+    describe "float types" do
+      subject { indexes.on(:latitude) }
+
+      it "has 1 index defined" do
+        expect(subject.length).to eq(1)
+      end
+
+      it { should have_a_range_index("latitude_range") }
+    end
   end
 end

--- a/spec/active_stash/stash_indexes_spec.rb
+++ b/spec/active_stash/stash_indexes_spec.rb
@@ -1,28 +1,8 @@
 require_relative "../support/user2"
 require_relative "../support/migrations/create_users2"
+require_relative "../spec_helper.rb"
 
 require 'rspec/expectations'
-
-RSpec::Matchers.define :have_an_exact_index do |name|
-  match do |actual|
-    target = actual.find { |i| i.type == :exact }
-    !target.nil? && target.name == name
-  end
-end
-
-RSpec::Matchers.define :have_a_range_index do |name|
-  match do |actual|
-    target = actual.find { |i| i.type == :range }
-    !target.nil? && target.name == name
-  end
-end
-
-RSpec::Matchers.define :have_a_match_index do |name|
-  match do |actual|
-    target = actual.find { |i| i.type == :match }
-    !target.nil? && target.name == name
-  end
-end
 
 RSpec.describe ActiveStash::StashIndexes do
   before(:all) do

--- a/spec/active_stash/unique_indexes_spec.rb
+++ b/spec/active_stash/unique_indexes_spec.rb
@@ -1,43 +1,9 @@
 require_relative "../support/user_unique_indexes"
 require_relative "../support/user_invalid_unique_indexes"
 require_relative "../support/migrations/create_users2"
+require_relative "../spec_helper.rb"
 
 require 'rspec/expectations'
-
-RSpec::Matchers.define :have_an_exact_index do |name|
-  match do |actual|
-    target = actual.find { |i| i.type == :exact }
-    !target.nil? && target.name == name
-  end
-end
-
-RSpec::Matchers.define :have_an_exact_unique_index do |name|
-  match do |actual|
-    target = actual.find { |i| i.type == :exact}
-    !target.nil? && target.name == name && target.unique == true
-  end
-end
-
-RSpec::Matchers.define :have_a_range_index do |name|
-  match do |actual|
-    target = actual.find { |i| i.type == :range }
-    !target.nil? && target.name == name
-  end
-end
-
-RSpec::Matchers.define :have_a_range_unique_index do |name|
-  match do |actual|
-    target = actual.find { |i| i.type == :range }
-    !target.nil? && target.name == name  && target.unique == true
-  end
-end
-
-RSpec::Matchers.define :have_a_match_index do |name|
-  match do |actual|
-    target = actual.find { |i| i.type == :match }
-    !target.nil? && target.name == name
-  end
-end
 
 RSpec.describe ActiveStash::StashIndexes do
   before(:all) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,3 +39,40 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+
+RSpec::Matchers.define :have_an_exact_index do |name|
+  match do |actual|
+    target = actual.find { |i| i.type == :exact }
+    !target.nil? && target.name == name
+  end
+end
+
+RSpec::Matchers.define :have_an_exact_unique_index do |name|
+  match do |actual|
+    target = actual.find { |i| i.type == :exact}
+    !target.nil? && target.name == name && target.unique == true
+  end
+end
+
+
+RSpec::Matchers.define :have_a_range_index do |name|
+  match do |actual|
+    target = actual.find { |i| i.type == :range }
+    !target.nil? && target.name == name
+  end
+end
+
+RSpec::Matchers.define :have_a_range_unique_index do |name|
+  match do |actual|
+    target = actual.find { |i| i.type == :range }
+    !target.nil? && target.name == name  && target.unique == true
+  end
+end
+
+RSpec::Matchers.define :have_a_match_index do |name|
+  match do |actual|
+    target = actual.find { |i| i.type == :match }
+    !target.nil? && target.name == name
+  end
+end

--- a/spec/support/migrations/create_users4.rb
+++ b/spec/support/migrations/create_users4.rb
@@ -1,0 +1,12 @@
+class CreateUsers4 < ActiveRecord::Migration[(ENV["RAILS_VERSION"] || "7.0").to_f]
+  def change
+    create_table :users4 do |t|
+      t.string :first_name
+      t.boolean :verified
+      t.date :dob
+      t.float :latitude
+      t.timestamps
+      t.uuid :stash_id
+    end
+  end
+end

--- a/spec/support/user4.rb
+++ b/spec/support/user4.rb
@@ -1,11 +1,13 @@
 class User4 < ActiveRecord::Base
-  # Used to test active record encryption in on different data types.
+  # Used to test active record encryption on different data types.
   include ActiveStash::Search
   include ActiveStash::Validations
 
   self.table_name = "users4"
   self.collection_name = "activestash_test_#{ENV["ACTIVE_STASH_TEST_COLLECTION_PREFIX"] || ""}_users4"
   
-  encrypts :first_name, :verified, :dob, :latitude
+  if Rails::VERSION::MAJOR >= 7
+    encrypts :first_name, :verified, :dob, :latitude
+  end
   stash_index :first_name, :verified, :dob, :latitude
 end

--- a/spec/support/user4.rb
+++ b/spec/support/user4.rb
@@ -1,0 +1,8 @@
+class User4 < ActiveRecord::Base
+  include ActiveStash::Search
+  include ActiveStash::Validations
+  self.table_name = "users4"
+  self.collection_name = "activestash_test_#{ENV["ACTIVE_STASH_TEST_COLLECTION_PREFIX"] || ""}_users4"
+  encrypts :first_name, :verified, :dob, :latitude
+  stash_index :first_name, :verified, :dob, :latitude
+end

--- a/spec/support/user4.rb
+++ b/spec/support/user4.rb
@@ -1,8 +1,11 @@
 class User4 < ActiveRecord::Base
+  # Used to test active record encryption in on different data types.
   include ActiveStash::Search
   include ActiveStash::Validations
+
   self.table_name = "users4"
   self.collection_name = "activestash_test_#{ENV["ACTIVE_STASH_TEST_COLLECTION_PREFIX"] || ""}_users4"
+  
   encrypts :first_name, :verified, :dob, :latitude
   stash_index :first_name, :verified, :dob, :latitude
 end


### PR DESCRIPTION
This PR fixes an issue where incorrect indexes are being created for anything other than a string type.

This is due to active record setting the type for all encrypted attributes to text.

More info here https://cipherstash.slack.com/archives/C01G7UGNQ3U/p1661470867621559

I have tested out Lockbox, and this doesn't have the same issue. The setup includes a step where you specify the type on the encrypted field in the model. In ActiveStash, it comes through as an ActiveModel type, with the actual type.

```
Key:
"age"
Value:
#<ActiveModel::Type::Integer:0x0000000146749ae0 @precision=nil, @scale=nil, @limit=8, @range=-9223372036854775808...9223372036854775808>
```

