### PR TITLE
Check for workspace arg when logging in

### DIFF
--- a/lib/tasks/active_stash.rake
+++ b/lib/tasks/active_stash.rake
@@ -56,6 +56,20 @@ namespace :active_stash do
 
   desc "Login to stash workspace"
   task :login, [:workspace] do |task, args|
+    if args[:workspace].nil?
+        error("Please provide a workspace ID.")
+        info("")
+        info("Using bash:")
+        info("")
+        info("rake active_stash:login[YOURWORKSPACEID]")
+        info("")
+        info("Using zsh:")
+        info("")
+        info("rake active_stash:login\\[YOURWORKSPACEID\\]")
+        info("")
+        info("")
+        exit 1
+    end
     CipherStash::Client::Profile.create(ENV.fetch("CS_PROFILE_NAME", "default"), ActiveStash::Logger.instance, workspace: args[:workspace])
   end
 


### PR DESCRIPTION
Adds a check for workspace id when running login.

Returns error if one isn't provided, and provides an example of how to provide it.

<img width="928" alt="Screen Shot 2022-08-29 at 11 07 36 am" src="https://user-images.githubusercontent.com/26052576/187103849-e698f154-029a-46e4-bf52-0ff42e4af5fb.png">

