### PR TITLE
Rescue errors on login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Support for filter parameters.
+* Error handling on StashRB errors returned when logging in.
 
 ## [0.7.1]
 

--- a/lib/tasks/active_stash.rake
+++ b/lib/tasks/active_stash.rake
@@ -72,7 +72,8 @@ namespace :active_stash do
     end
     CipherStash::Client::Profile.create(ENV.fetch("CS_PROFILE_NAME", "default"), ActiveStash::Logger.instance, workspace: args[:workspace])
   rescue CipherStash::Client::Error::CreateProfileFailure => ex
-    puts "handling error for create profile here"
+    error(ex.message)
+  rescue CipherStash::Client::Error::LoadProfileFailure => ex
     error(ex.message)
   end
 

--- a/lib/tasks/active_stash.rake
+++ b/lib/tasks/active_stash.rake
@@ -71,6 +71,9 @@ namespace :active_stash do
         exit 1
     end
     CipherStash::Client::Profile.create(ENV.fetch("CS_PROFILE_NAME", "default"), ActiveStash::Logger.instance, workspace: args[:workspace])
+  rescue CipherStash::Client::Error::CreateProfileFailure => ex
+    puts "handling error for create profile here"
+    error(ex.message)
   end
 
   desc "Reindex the CipherStash collection for the given model"


### PR DESCRIPTION
Adds rescue's to handle failures gracefully when load or create profile errors are returned.

Before

<img width="668" alt="Screen Shot 2022-08-29 at 3 58 42 pm" src="https://user-images.githubusercontent.com/26052576/187132960-22963fad-272b-4fb9-93c9-36fa2587c9dd.png">


After

<img width="666" alt="Screen Shot 2022-08-29 at 3 59 50 pm" src="https://user-images.githubusercontent.com/26052576/187132976-5f4eb243-3cfd-407e-9d9c-1b0cc328c9d7.png">
