### PR TITLE
Raise error in RSpec matcher when assessment is outdated

### DIFF
--- a/lib/active_stash/assess/column_name_rules.rb
+++ b/lib/active_stash/assess/column_name_rules.rb
@@ -34,11 +34,12 @@ module ActiveStash
       def self.check(field_names)
         {}.tap do |matches|
           field_names.each do |field_name|
+            matches[field_name] ||= []
+
             normalized_field_name = field_name.gsub("_", "").singularize
             suspects = RULES.select { |rule| rule[:column_names].include?(normalized_field_name) }
 
             if suspects.size > 0
-              matches[field_name] ||= []
               matches[field_name] << suspects
               matches[field_name].flatten!
             end

--- a/lib/active_stash/error.rb
+++ b/lib/active_stash/error.rb
@@ -61,4 +61,7 @@ module ActiveStash
 
   # Raised when an assessment file is not found (likely because it has not been generated).
   class AssessmentNotFound < AssessError; end
+
+  # Raised when an assessment file is out of date and needs to be updated.
+  class AssessmentOutdated < AssessError; end
 end

--- a/lib/tasks/active_stash.rake
+++ b/lib/tasks/active_stash.rake
@@ -23,8 +23,8 @@ end
 
 namespace :active_stash do
   desc "Assess sensitive data used in a Rails application and generate a report"
-  task(:assess => :environment) do
-    ActiveStash::Assess.new.run
+  task(:assess, [:quiet] => :environment) do |task, args|
+    ActiveStash::Assess.new(**args.to_hash).run
   end
 
   desc "Signup"
@@ -172,5 +172,11 @@ namespace :active_stash do
 
       puts table
     end
+  end
+end
+
+Rake::Task["db:migrate"].enhance do
+  if ActiveStash::Assess.report_exists?
+    Rake::Task["active_stash:assess"].execute({quiet: true})
   end
 end


### PR DESCRIPTION
This PR updates the `ecrypt_sensitive_fields` RSpec matcher to raise an error (and fail the test) when the assessment file is outdated.

This works by:
1. Recording all fields currently on each model when the report is generated
2. Checking that the current fields on the model being tested match the fields recorded in the assessment file

Here's an example of the error message for an outdated assessment file:
<img width="853" alt="Screen Shot 2022-09-20 at 5 20 34 pm" src="https://user-images.githubusercontent.com/7672425/191379557-7ddb9aca-925c-4154-b94a-44d4b92ae742.png">

And here's an example of the new format for the assessment file to support this:
```yml
---
User:
- :field: id
  :sensitive: false
- :field: name
  :sensitive: true
  :comment: 'suspected to contain: names'
- :field: email
  :sensitive: true
  :comment: 'suspected to contain: emails'
- :field: password_digest
  :sensitive: false
- :field: gender
  :sensitive: true
  :comment: 'suspected to contain: genders'
- :field: title
  :sensitive: false
- :field: ccn
  :sensitive: true
  :comment: 'suspected to contain: credit card numbers'
- :field: dob
  :sensitive: true
  :comment: 'suspected to contain: dates of birth'
- :field: created_at
  :sensitive: false
- :field: updated_at
  :sensitive: false
- :field: stash_id
  :sensitive: false
```

To help prevent outdated assessment files, this change also adds logic for running `active_stash:assess` after `db:migrate` runs.
