### PR TITLE
Assess: Check encrypted attributes is an array

### DIFF
--- a/lib/active_stash/assess/column_name_rules.rb
+++ b/lib/active_stash/assess/column_name_rules.rb
@@ -13,7 +13,7 @@ module ActiveStash
         { name: 'last_name', display_name: 'names', column_names: %w[name fname firstname lastname lname surname], error_code: ERR_PII },
         { name: 'phone', display_name: 'phone numbers', column_names: %w[phone phonenumber], error_code: ERR_PII },
         { name: 'date_of_birth', display_name: 'dates of birth', column_names: %w[dateofbirth birthday dob], error_code: ERR_PII },
-        { name: 'address', display_name: 'addresses', column_names: %w[address city state county country zip zipcode postalcode postcode postal], error_code: ERR_PII },
+        { name: 'address', display_name: 'addresses', column_names: %w[address city suburb state county country zip zipcode postalcode postcode postal], error_code: ERR_PII },
         { name: 'oauth_token', display_name: 'OAuth tokens', column_names: %w[accesstoken refreshtoken], error_code: ERR_AUTH },
         { name: 'email', display_name: 'emails', column_names: ['email'], error_code: ERR_PII },
         { name: 'ip_address', display_name: 'IP addresses', column_names: %w[ip ipaddress], error_code: ERR_PII },

--- a/lib/active_stash/matchers.rb
+++ b/lib/active_stash/matchers.rb
@@ -27,7 +27,7 @@ if defined?(RSpec)
     end
 
     def encrypted?(model, field_name)
-      model.respond_to?(:encrypted_attributes) && model.encrypted_attributes.include?(field_name)
+      model.respond_to?(:encrypted_attributes) && model.encrypted_attributes.kind_of?(Array) && model.encrypted_attributes.include?(field_name)
     end
   end
 end

--- a/spec/active_stash/assess/column_name_rules_spec.rb
+++ b/spec/active_stash/assess/column_name_rules_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe ActiveStash::Assess::ColumnNameRules do
       ["dob", "dates of birth", "AS0001"],
       ["address", "addresses", "AS0001"],
       ["city", "addresses", "AS0001"],
+      ["suburb", "addresses", "AS0001"],
       ["state", "addresses", "AS0001"],
       ["county", "addresses", "AS0001"],
       ["country", "addresses", "AS0001"],


### PR DESCRIPTION
When running the RSpec matcher against a model that doesn't have any encrypted fields added yet, the below response is returned on the test.

```
Pending: (Failures listed here are expected and do not affect your suite's status)

  1) User encrypts sensitive fields
     # unenforced
     Failure/Error: expect(described_class).to encrypt_sensitive_fields
     
     NoMethodError:
       undefined method `include?' for nil:NilClass
     # ./spec/models/user_spec.rb:7:in `block (2 levels) in <top (required)>'
```

This is because we are not checking for nil being returned if there are no encrypted attributes added yet.

This PR adds in a check that the encrypted attributes is an array, before checking the field name is included.

I'm also squeezing in, adding in `suburb` as a potential address field, as need this for the example in the getting started guide