### PR TITLE
Assess: check if encrypted attribute is a set not an array

### DIFF
--- a/lib/active_stash/matchers.rb
+++ b/lib/active_stash/matchers.rb
@@ -39,8 +39,6 @@ if defined?(RSpec)
     end
 
     def encrypted?(model, field_name)
-      # require 'pry'
-      # binding.pry
       model.respond_to?(:encrypted_attributes) && model.encrypted_attributes.kind_of?(Set) && model.encrypted_attributes.include?(field_name)
     end
 

--- a/lib/active_stash/matchers.rb
+++ b/lib/active_stash/matchers.rb
@@ -39,7 +39,9 @@ if defined?(RSpec)
     end
 
     def encrypted?(model, field_name)
-      model.respond_to?(:encrypted_attributes) && model.encrypted_attributes.kind_of?(Array) && model.encrypted_attributes.include?(field_name)
+      # require 'pry'
+      # binding.pry
+      model.respond_to?(:encrypted_attributes) && model.encrypted_attributes.kind_of?(Set) && model.encrypted_attributes.include?(field_name)
     end
 
     # Check if all fields in the model are in the report. We only care if the fields for the


### PR DESCRIPTION
The data type of encrypted attributes is a Set not an Array.

Fixes the check on encrypted attributes to check for a Set type, not an array.

<img width="1153" alt="Screen Shot 2022-09-21 at 3 45 30 pm" src="https://user-images.githubusercontent.com/26052576/191424181-320e5314-6b54-4b03-be67-8cbd1168d416.png">
