### PR TITLE
Add Lockbox support to encrypt_sensitive_fields matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ The `active_stash:assess` Rake task also writes a results file to `active_stash_
 
 ### RSpec matcher
 
-After a report has been generated, you can use the `encrypt_sensitive_fields` RSpec matcher to verify that a model encrypts fields that were reported as sensitive by `rake active_stash:assess`.
+After a report has been generated, you can use the `encrypt_sensitive_fields` RSpec matcher to verify that a model encrypts fields (using either [Lockbox](https://github.com/ankane/lockbox) or [ActiveRecord Encryption](https://guides.rubyonrails.org/active_record_encryption.html)) that were reported as sensitive by `rake active_stash:assess`.
 
 First, make sure that the matcher is required in `spec/rails_helper.rb`:
 ```ruby
@@ -632,8 +632,6 @@ This helps you keep track of what fields you need to encrypt, as you incremental
 As the example above shows, we recommend you start out by marking the test as [pending](https://relishapp.com/rspec/rspec-core/v/3-0/docs/pending-and-skipped-examples).
 This will stop the test from failing while you incrementally encrypt database fields.
 Once you have encrypted all the fields identified by ActiveStash Assess, remove the pending so your tests will fail if the database field becomes unencrypted.
-
-The `encrypt_sensitive_fields` matcher currently verifies that fields have been encrypted using [ActiveRecord Encryption](https://guides.rubyonrails.org/active_record_encryption.html), but support for [Lockbox](https://github.com/ankane/lockbox) is planned.
 
 ## Development
 

--- a/activestash.gemspec
+++ b/activestash.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "github-release", "~> 0.2"
+  spec.add_development_dependency "lockbox", "~> 1.0"
 
   spec.files = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*"]
   spec.bindir        = "exe"

--- a/lib/tasks/active_stash.rake
+++ b/lib/tasks/active_stash.rake
@@ -24,6 +24,12 @@ end
 namespace :active_stash do
   desc "Assess sensitive data used in a Rails application and generate a report"
   task(:assess, [:quiet] => :environment) do |task, args|
+    if !defined?(Rails)
+      raise ActiveStash::RailsUndefinedError, "ActiveStash Assess can currently only be used in Rails projects"
+    end
+
+    Rails.application.eager_load!
+
     ActiveStash::Assess.new(**args.to_hash).run
   end
 
@@ -177,7 +183,7 @@ end
 
 if Rake::Task.task_defined?("db:migrate")
   Rake::Task["db:migrate"].enhance do
-    if ActiveStash::Assess.report_exists?
+    if ActiveStash::Assess.new.report_exists?
       Rake::Task["active_stash:assess"].execute({quiet: true})
     end
   end

--- a/spec/active_stash/assess_spec.rb
+++ b/spec/active_stash/assess_spec.rb
@@ -1,0 +1,122 @@
+
+require "active_stash/matchers"
+
+RSpec.describe ActiveStash::Assess do
+  describe "running an assessment and using the encrypt_sensitive_fields matcher" do
+    it "succeeds when there are no models" do
+      Dir.mktmpdir do |tmpdir|
+        report_dir = Pathname.new(tmpdir)
+        assess = described_class.new(models: [], report_dir: report_dir)
+
+        expected_output = "Assessment written to: #{report_dir}\/active_stash_assessment.yml\n"
+
+        expect { assess.run }.to output(expected_output).to_stdout
+
+        expect(assess.read_report).to eq({})
+      end
+    end
+
+    it "succeeds for a model with no encrypted fields" do
+      Dir.mktmpdir do |tmpdir|
+        report_dir = Pathname.new(tmpdir)
+        assess = described_class.new(models: [AssessUserNoEncryption], report_dir: report_dir)
+
+        expected_output = <<~STR
+        AssessUserNoEncryption:
+        - AssessUserNoEncryption.email is suspected to contain: emails (AS0001)
+
+        Online documentation:
+        - https://docs.cipherstash.com/assess/checks#AS0001
+
+        Assessment written to: #{report_dir}\/active_stash_assessment.yml
+        STR
+
+        expected_report = {
+          "AssessUserNoEncryption" => [
+            {field: "id", sensitive: false},
+            {comment: "suspected to contain: emails", field: "email", sensitive: true},
+            {field: "created_at", sensitive: false},
+            {field: "updated_at", sensitive: false},
+          ]
+        }
+
+        expect { assess.run }.to output(expected_output).to_stdout
+
+        expect(assess.read_report).to eq(expected_report)
+
+        expect do
+          expect(AssessUserNoEncryption).to encrypt_sensitive_fields(assess)
+        end.to raise_error("Unprotected sensitive field: email")
+      end
+    end
+
+    if Rails::VERSION::MAJOR >= 7
+      it "succeeds for a model with active record encryption" do
+        Dir.mktmpdir do |tmpdir|
+          report_dir = Pathname.new(tmpdir)
+          assess = described_class.new(models: [AssessUserActiveRecordEncryption], report_dir: report_dir)
+
+          expected_output = <<~STR
+          AssessUserActiveRecordEncryption:
+          - AssessUserActiveRecordEncryption.email is suspected to contain: emails (AS0001)
+
+          Online documentation:
+          - https://docs.cipherstash.com/assess/checks#AS0001
+
+          Assessment written to: #{report_dir}\/active_stash_assessment.yml
+          STR
+
+          expected_report = {
+            "AssessUserActiveRecordEncryption" => [
+              {field: "id", sensitive: false},
+              {comment: "suspected to contain: emails", field: "email", sensitive: true},
+              {field: "created_at", sensitive: false},
+              {field: "updated_at", sensitive: false},
+            ]
+          }
+
+          expect { assess.run }.to output(expected_output).to_stdout
+
+          expect(assess.read_report).to eq(expected_report)
+
+          expect(AssessUserActiveRecordEncryption).to encrypt_sensitive_fields(assess)
+        end
+      end
+    end
+
+    it "succeeds for a model with lockbox" do
+      Dir.mktmpdir do |tmpdir|
+        report_dir = Pathname.new(tmpdir)
+        assess = described_class.new(models: [AssessUserLockbox], report_dir: report_dir)
+
+        # Note that names aren't in the output here because the column is suffixed with _ciphertext
+        expected_output = <<~STR
+        AssessUserLockbox:
+        - AssessUserLockbox.email is suspected to contain: emails (AS0001)
+
+        Online documentation:
+        - https://docs.cipherstash.com/assess/checks#AS0001
+
+        Assessment written to: #{report_dir}\/active_stash_assessment.yml
+        STR
+
+        expected_report = {
+          "AssessUserLockbox" => [
+            {field: "id", sensitive: false},
+            {comment: "suspected to contain: emails", field: "email", sensitive: true},
+            # name is in the report, but it's not marked as sensitive because of the suffix
+            {:field=>"name_ciphertext", :sensitive=>false},
+            {field: "created_at", sensitive: false},
+            {field: "updated_at", sensitive: false},
+          ]
+        }
+
+        expect { assess.run }.to output(expected_output).to_stdout
+
+        expect(assess.read_report).to eq(expected_report)
+
+        expect(AssessUserLockbox).to encrypt_sensitive_fields(assess)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,9 @@ RSpec.configure do |config|
     # We do not have Rails auto-loaders so we must take care to load models in a sensible order.
     require './spec/support/patient'
     require './spec/support/medicare_card'
+    require './spec/support/assess_user_active_record_encryption'
+    require './spec/support/assess_user_lockbox'
+    require './spec/support/assess_user_no_encryption'
     require './spec/support/user'
     require './spec/support/user2'
     require './spec/support/user3'

--- a/spec/support/assess_user_active_record_encryption.rb
+++ b/spec/support/assess_user_active_record_encryption.rb
@@ -1,0 +1,7 @@
+class AssessUserActiveRecordEncryption < ActiveRecord::Base
+  self.table_name = "assess_users_active_record_encryption"
+
+  if Rails::VERSION::MAJOR >= 7
+    encrypts :email
+  end
+end

--- a/spec/support/assess_user_lockbox.rb
+++ b/spec/support/assess_user_lockbox.rb
@@ -1,0 +1,11 @@
+require "lockbox"
+
+class AssessUserLockbox < ActiveRecord::Base
+  self.table_name = "assess_users_lockbox"
+
+  # non-default column name
+  has_encrypted :encrypted_email, encrypted_attribute: :email
+
+  # default column name (name_ciphertext)
+  has_encrypted :name
+end

--- a/spec/support/assess_user_no_encryption.rb
+++ b/spec/support/assess_user_no_encryption.rb
@@ -1,0 +1,3 @@
+class AssessUserNoEncryption < ActiveRecord::Base
+  self.table_name = "assess_users_no_encryption"
+end

--- a/spec/support/migrations/create_assess_tables.rb
+++ b/spec/support/migrations/create_assess_tables.rb
@@ -1,0 +1,19 @@
+class CreateAssessTables < ActiveRecord::Migration[(ENV["RAILS_VERSION"] || "7.0").to_f]
+  def change
+    create_table :assess_users_no_encryption do |t|
+      t.string :email
+      t.timestamps
+    end
+
+    create_table :assess_users_active_record_encryption do |t|
+      t.string :email
+      t.timestamps
+    end
+
+    create_table :assess_users_lockbox do |t|
+      t.string :email
+      t.string :name_ciphertext
+      t.timestamps
+    end
+  end
+end

--- a/spec/support/user3.rb
+++ b/spec/support/user3.rb
@@ -4,7 +4,7 @@ class User3 < ActiveRecord::Base
   include ActiveStash::Search
   include ActiveStash::Validations
   self.table_name = "users3"
-  self.collection_name = "activestash_test_#{ENV["ACTIVE_STASH_TEST_COLLECTION_PREFIX"] || ""}_users"
+  self.collection_name = "activestash_test_#{ENV["ACTIVE_STASH_TEST_COLLECTION_PREFIX"] || ""}_users3"
 
   # Used for testing
   attr_accessor :skip_validations


### PR DESCRIPTION
This PR adds Lockbox support to the `encrypt_sensitive_fields` matcher and adds specs for Assess (both the task and matcher).

Note that columns that follow the Lockbox convention of using a `_ciphertext` suffix will still not show up as sensitive in the assessment. However, columns that use non-default names (e.g. don't use the suffix) and get picked up as sensitive will be properly marked as encrypted.

I've also fixed a typo in the `User3` model that could cause test flake.