### PR TITLE
Fix describe collection task error

### DIFF
--- a/lib/tasks/active_stash.rake
+++ b/lib/tasks/active_stash.rake
@@ -175,8 +175,10 @@ namespace :active_stash do
   end
 end
 
-Rake::Task["db:migrate"].enhance do
-  if ActiveStash::Assess.report_exists?
-    Rake::Task["active_stash:assess"].execute({quiet: true})
+if Rake::Task.task_defined?("db:migrate")
+  Rake::Task["db:migrate"].enhance do
+    if ActiveStash::Assess.report_exists?
+      Rake::Task["active_stash:assess"].execute({quiet: true})
+    end
   end
 end

--- a/lib/tasks/active_stash.rake
+++ b/lib/tasks/active_stash.rake
@@ -129,7 +129,7 @@ namespace :active_stash do
     task :describe, [:name] => :environment do |task, args|
       model = args[:name].constantize
       table = Terminal::Table.new(headings: ["Name", "Type", "Field(s)", "Valid Operators"]) do |t|
-        model.stash_indexes.all.each do |index|
+        model.stash_indexes.indexes.each do |index|
           t << [index.name, index.type, Array(index.field).join(", "), index.valid_ops.join(", ")]
         end
       end

--- a/spec/tasks/collections/describe_spec.rb
+++ b/spec/tasks/collections/describe_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+require "rake"
+
+RSpec.describe "active_stash:collections:describe" do
+  before do
+    Rake.application.rake_require "tasks/active_stash"
+    Rake::Task.define_task(:environment)
+
+    User.collection.create!
+  end
+
+  after do
+    User.collection.drop!
+  end
+
+  it "succeeds given a model that uses ActiveStash::Search" do
+    expected_output = <<~STR
+    +---------------------------------+-------+------------------------------+---------------------------+
+    | Name                            | Type  | Field(s)                     | Valid Operators           |
+    +---------------------------------+-------+------------------------------+---------------------------+
+    | first_name_range                | range | first_name                   | <, <=, >, >=, ==, between |
+    | first_name                      | exact | first_name                   | ==                        |
+    | first_name_match                | match | first_name                   | =~                        |
+    | dob_range                       | range | dob                          | <, <=, >, >=, ==, between |
+    | created_at_range                | range | created_at                   | <, <=, >, >=, ==, between |
+    | gender                          | exact | gender                       | ==                        |
+    | email                           | exact | email                        | ==                        |
+    | __match_multi                   | match | first_name, last_name, email | =~                        |
+    | patient.height_range            | range | height                       | <, <=, >, >=, ==, between |
+    | patient.weight_range            | range | weight                       | <, <=, >, >=, ==, between |
+    | medicare_card.medicare_number   | exact | medicare_number              | ==                        |
+    | medicare_card.expiry_date_range | range | expiry_date                  | <, <=, >, >=, ==, between |
+    +---------------------------------+-------+------------------------------+---------------------------+
+    STR
+
+    expect do
+      Rake.application.invoke_task("active_stash:collections:describe[User]")
+    end.to output(expected_output).to_stdout
+  end
+end


### PR DESCRIPTION
This PR fixes a `NoMethodError` while running `rake active_stash:collections:describe`.

The error before was:
```
NoMethodError: undefined method all for #ActiveStash::IndexLookup:0x000000013087cec8
```

`all` is no longer a method on `stash_indexes` (likely from the change in https://github.com/cipherstash/activestash/pull/79). We can use `stash_indexes.indexes` instead.