### PR TITLE
Update login rake task to use CipherStash::Client.login

### DIFF
--- a/activestash.gemspec
+++ b/activestash.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.metadata["documentation_uri"] = "https://rubydoc.info/gems/active_stash"
   spec.metadata["mailing_list_uri"] = "https://discuss.cipherstash.com"
 
-  spec.add_runtime_dependency "cipherstash-client", "~> 0.15.1"
+  spec.add_runtime_dependency "cipherstash-client", "~> 0.16"
   spec.add_runtime_dependency "activerecord"
   spec.add_runtime_dependency "terminal-table", "~> 3.0"
   spec.add_runtime_dependency "launchy", "~> 2.5"

--- a/activestash.gemspec
+++ b/activestash.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.metadata["documentation_uri"] = "https://rubydoc.info/gems/active_stash"
   spec.metadata["mailing_list_uri"] = "https://discuss.cipherstash.com"
 
-  spec.add_runtime_dependency "cipherstash-client", "~> 0.16"
+  spec.add_runtime_dependency "cipherstash-client", "~> 0.16.1"
   spec.add_runtime_dependency "activerecord"
   spec.add_runtime_dependency "terminal-table", "~> 3.0"
   spec.add_runtime_dependency "launchy", "~> 2.5"

--- a/lib/tasks/active_stash.rake
+++ b/lib/tasks/active_stash.rake
@@ -65,23 +65,19 @@ namespace :active_stash do
     info("")
   end
 
-  desc "Login to stash workspace"
+  desc <<~STR
+  Log into a CipherStash workspace.
+
+  If given a single arg, workspace, a profile will be created for that workspace.
+  This is useful for logging into a workspace for the first time.
+
+  If a workspace is not provided, this command will load an existing profile and
+  then log in using that profile. The profile name defaults to "default", but can
+  be overridden with the `CS_PROFILE_NAME` env var or the `defaultProfile` opt in
+  `{cs_config_path}/config.json`.
+  STR
   task :login, [:workspace] do |task, args|
-    if args[:workspace].nil?
-        error("Please provide a workspace ID.")
-        info("")
-        info("Using bash:")
-        info("")
-        info("rake active_stash:login[YOURWORKSPACEID]")
-        info("")
-        info("Using zsh:")
-        info("")
-        info("rake active_stash:login\\[YOURWORKSPACEID\\]")
-        info("")
-        info("")
-        exit 1
-    end
-    CipherStash::Client::Profile.create(ENV.fetch("CS_PROFILE_NAME", "default"), ActiveStash::Logger.instance, workspace: args[:workspace])
+    CipherStash::Client::login(workspace: args[:workspace], logger: ActiveStash::Logger.instance)
   rescue CipherStash::Client::Error::CreateProfileFailure => ex
     error(ex.message)
   rescue CipherStash::Client::Error::LoadProfileFailure => ex

--- a/lib/tasks/active_stash.rake
+++ b/lib/tasks/active_stash.rake
@@ -81,7 +81,18 @@ namespace :active_stash do
   rescue CipherStash::Client::Error::CreateProfileFailure => ex
     error(ex.message)
   rescue CipherStash::Client::Error::LoadProfileFailure => ex
-    error(ex.message)
+    message = <<~STR
+    Could not log in because a profile could not be loaded.
+
+    If you're logging into a workspace for the first time, make sure that you've provided a workspace
+    and a profile will be created for you.
+
+    Example: `rake active_stash:login[YourWorkspaceHere]`.
+
+    Otherwise, make sure that a profile named "default" exists or that a valid profile name has been
+    provided via the `CS_PROFILE_NAME` env var or the `defaultProfile` opt in `{cs_config_path}/config.json`.
+    STR
+    error(message)
   end
 
   desc "Reindex the CipherStash collection for the given model"

--- a/lib/tasks/active_stash.rake
+++ b/lib/tasks/active_stash.rake
@@ -87,7 +87,15 @@ namespace :active_stash do
     If you're logging into a workspace for the first time, make sure that you've provided a workspace
     and a profile will be created for you.
 
-    Example: `rake active_stash:login[YourWorkspaceHere]`.
+    Example: 
+    
+    Using bash:
+    
+    `rake active_stash:login[YourWorkspaceHere]`
+    
+    Using zsh:
+    
+    `rake active_stash:login\[YourWorkspaceHere\]`
 
     Otherwise, make sure that a profile named "default" exists or that a valid profile name has been
     provided via the `CS_PROFILE_NAME` env var or the `defaultProfile` opt in `{cs_config_path}/config.json`.


### PR DESCRIPTION
This PR fixes a bug where users were not able to log in using existing profiles via `rake active_stash:login`.

Related ruby-client PR: https://github.com/cipherstash/ruby-client/pull/23.

Note: this PR does not change the behaviour that existing profiles can be clobbered when running `rake active_stash:login` with the workspace arg.