### PR TITLE
Update ngram tokenization setting

### DIFF
--- a/activestash.gemspec
+++ b/activestash.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.metadata["documentation_uri"] = "https://rubydoc.info/gems/active_stash"
   spec.metadata["mailing_list_uri"] = "https://discuss.cipherstash.com"
 
-  spec.add_runtime_dependency "cipherstash-client", "~> 0.17.0"
+  spec.add_runtime_dependency "cipherstash-client", "~> 0.18.0"
   spec.add_runtime_dependency "activerecord"
   spec.add_runtime_dependency "terminal-table", "~> 3.0"
   spec.add_runtime_dependency "launchy", "~> 2.5"

--- a/lib/active_stash/schema_builder.rb
+++ b/lib/active_stash/schema_builder.rb
@@ -63,7 +63,7 @@ module ActiveStash
         "fields" => Array(index.field),
         "tokenFilters" => [
           { "kind" => "downcase" },
-          { "kind" => "ngram", "tokenLength" => 3 }
+          { "kind" => "ngram", "minLength" => 3, "maxLength" => 8 }
         ],
         "tokenizer" => { "kind" => "standard" }
       }.tap do |idx|
@@ -121,7 +121,7 @@ module ActiveStash
         "kind" => "dynamic-match",
         "tokenFilters" => [
           { "kind" => "downcase" },
-          { "kind" => "ngram", "tokenLength" => 3 }
+          { "kind" => "ngram", "minLength" => 3, "maxLength" => 8}
         ],
         "tokenizer" => { "kind" => "standard" }
       }


### PR DESCRIPTION
Bumps cipherstash-client version to v0.18.0 which includes update to ngram tokenization.

Updates ngram tokenization settings to use min and max length.